### PR TITLE
LAB-724 support for attributes `::attr()`

### DIFF
--- a/panel-app/package-lock.json
+++ b/panel-app/package-lock.json
@@ -12,7 +12,7 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@ionic/core": "^7.5.4",
+				"@ionic/core": "^7.5.5",
 				"@stencil-community/router": "^1.0.2",
 				"@stencil/core": "4.7.2",
 				"@stencil/sass": "^3.0.7",
@@ -21,7 +21,7 @@
 				"@types/jest": "^29.5.8",
 				"jest": "^29.7.0",
 				"jest-cli": "^29.7.0",
-				"puppeteer": "^21.5.1"
+				"puppeteer": "^21.5.2"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -657,12 +657,12 @@
 			"dev": true
 		},
 		"node_modules/@ionic/core": {
-			"version": "7.5.4",
-			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.5.4.tgz",
-			"integrity": "sha512-rZbKlcVucRTDOK2Woh4CWPePlsXiUt3G9dCUniduKD7WeiuAk0GzfmoM3WXBvcUpkVTUIOrvKHaqd3JJSWEIzg==",
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.5.5.tgz",
+			"integrity": "sha512-7Rn3OUz8QCob7yMuCLs5dVLpChscNCm+OqH8lqTzy3N/8VSKHLNPHIHTIa4DQm9HwjtpOB+XCTeIqbdWHkLgnA==",
 			"dev": true,
 			"dependencies": {
-				"@stencil/core": "^4.7.1",
+				"@stencil/core": "^4.7.2",
 				"ionicons": "^7.2.1",
 				"tslib": "^2.1.0"
 			}
@@ -1946,9 +1946,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.582",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.582.tgz",
-			"integrity": "sha512-89o0MGoocwYbzqUUjc+VNpeOFSOK9nIdC5wY4N+PVUarUK0MtjyTjks75AZS2bW4Kl8MdewdFsWaH0jLy+JNoA==",
+			"version": "1.4.584",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.584.tgz",
+			"integrity": "sha512-rXCtDiXCBtfTfEegkthruCvyWZnr1/FCrUGY/nYQiF+lSZDmwQBDxp0rivZxV8trXb6cbgojhcSTW5xsDcHQ8g==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -3847,24 +3847,24 @@
 			}
 		},
 		"node_modules/puppeteer": {
-			"version": "21.5.1",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.1.tgz",
-			"integrity": "sha512-NkI06BXckVZeZUkODK+BbgGelQSu7uYEp9PaJDozxpwNRFDYoVfHQvd2G4dERoLdP6+qx4EBPwEhk4dEkQc2Kg==",
+			"version": "21.5.2",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.2.tgz",
+			"integrity": "sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"@puppeteer/browsers": "1.8.0",
 				"cosmiconfig": "8.3.6",
-				"puppeteer-core": "21.5.1"
+				"puppeteer-core": "21.5.2"
 			},
 			"engines": {
-				"node": ">=16.3.0"
+				"node": ">=16.13.2"
 			}
 		},
 		"node_modules/puppeteer-core": {
-			"version": "21.5.1",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.1.tgz",
-			"integrity": "sha512-u6c3SZKAOaOQogaTkQvllxT/o2PP16wkbrUWINtMhfvrB4ko+xwqC1pb+vyCPMmNUh3N/CX5YGqb3DWx2fUPSQ==",
+			"version": "21.5.2",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.2.tgz",
+			"integrity": "sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==",
 			"dev": true,
 			"dependencies": {
 				"@puppeteer/browsers": "1.8.0",
@@ -3875,7 +3875,7 @@
 				"ws": "8.14.2"
 			},
 			"engines": {
-				"node": ">=16.3.0"
+				"node": ">=16.13.2"
 			}
 		},
 		"node_modules/pure-rand": {

--- a/panel-app/package.json
+++ b/panel-app/package.json
@@ -11,7 +11,7 @@
 		"generate": "stencil generate"
 	},
 	"devDependencies": {
-		"@ionic/core": "^7.5.4",
+		"@ionic/core": "^7.5.5",
 		"@stencil-community/router": "^1.0.2",
 		"@stencil/core": "4.7.2",
 		"@stencil/sass": "^3.0.7",
@@ -20,7 +20,7 @@
 		"@types/jest": "^29.5.8",
 		"jest": "^29.7.0",
 		"jest-cli": "^29.7.0",
-		"puppeteer": "^21.5.1"
+		"puppeteer": "^21.5.2"
 	},
 	"dependencies": {
 		"@types/babel__traverse": "^7.20.4",

--- a/panel-app/src/components.d.ts
+++ b/panel-app/src/components.d.ts
@@ -5,14 +5,16 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
+import { Selector } from "./components/store";
+export { Selector } from "./components/store";
 export namespace Components {
     interface AppRoot {
     }
     interface CodeViewer {
     }
     interface CreateConfig {
-        "fileName": any;
-        "triggerType": any;
+        "fileName": string;
+        "triggerType": 'new-file' | 'load-file';
     }
     interface FileExplorer {
     }
@@ -22,19 +24,15 @@ export namespace Components {
         "type": string;
     }
     interface SelectElementItem {
-        "isBoolean"?: boolean;
         "name": string;
-        "selector": string;
-        "selectorType": string;
+        "selector": Selector;
         "type": string;
         "uniqueId": string;
     }
     interface SubItemInputElement {
-        "isBoolean": boolean;
         "name": string;
-        "selector": string;
-        "selectorType": string;
-        "type": string;
+        "selector": Selector;
+        "type": 'metadataItem' | 'subItem' | 'excludeItem';
         "uniqueId": string;
     }
     interface SubitemEditConfig {
@@ -137,8 +135,8 @@ declare namespace LocalJSX {
     interface CodeViewer {
     }
     interface CreateConfig {
-        "fileName"?: any;
-        "triggerType"?: any;
+        "fileName"?: string;
+        "triggerType"?: 'new-file' | 'load-file';
     }
     interface FileExplorer {
     }
@@ -148,20 +146,16 @@ declare namespace LocalJSX {
         "type"?: string;
     }
     interface SelectElementItem {
-        "isBoolean"?: boolean;
         "name"?: string;
-        "selector"?: string;
-        "selectorType"?: string;
+        "selector"?: Selector;
         "type"?: string;
         "uniqueId"?: string;
     }
     interface SubItemInputElement {
-        "isBoolean"?: boolean;
         "name"?: string;
         "onUpdateSubItem"?: (event: SubItemInputElementCustomEvent<any>) => void;
-        "selector"?: string;
-        "selectorType"?: string;
-        "type"?: string;
+        "selector"?: Selector;
+        "type"?: 'metadataItem' | 'subItem' | 'excludeItem';
         "uniqueId"?: string;
     }
     interface SubitemEditConfig {

--- a/panel-app/src/components.d.ts
+++ b/panel-app/src/components.d.ts
@@ -5,16 +5,14 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { Selector } from "./components/store";
-export { Selector } from "./components/store";
+import { Selector } from "./components/types";
+export { Selector } from "./components/types";
 export namespace Components {
     interface AppRoot {
     }
     interface CodeViewer {
     }
     interface CreateConfig {
-        "fileName": string;
-        "triggerType": 'new-file' | 'load-file';
     }
     interface FileExplorer {
     }
@@ -135,8 +133,6 @@ declare namespace LocalJSX {
     interface CodeViewer {
     }
     interface CreateConfig {
-        "fileName"?: string;
-        "triggerType"?: 'new-file' | 'load-file';
     }
     interface FileExplorer {
     }

--- a/panel-app/src/components/app-root/app-root.tsx
+++ b/panel-app/src/components/app-root/app-root.tsx
@@ -1,7 +1,8 @@
 /*global chrome*/
 
-import { Component, h } from '@stencil/core';
+import { Component, Host, h } from '@stencil/core';
 import logo from '../../assets/icon/CoveoLogo.svg';
+import state from '../store';
 
 @Component({
 	tag: 'app-root',
@@ -11,7 +12,7 @@ import logo from '../../assets/icon/CoveoLogo.svg';
 export class AppRoot {
 	render() {
 		return (
-			<div>
+			<Host>
 				<header id="top-bar">
 					<div class="header-container">
 						<ion-img id="coveo-logo-img" src={logo}></ion-img>
@@ -20,10 +21,8 @@ export class AppRoot {
 					</div>
 				</header>
 
-				<main>
-					<file-explorer></file-explorer>
-				</main>
-			</div>
+				{state.currentFile?.name ? <create-config /> : <file-explorer />}
+			</Host>
 		);
 	}
 }

--- a/panel-app/src/components/create-config/create-config.scss
+++ b/panel-app/src/components/create-config/create-config.scss
@@ -112,7 +112,7 @@
 					line-height: 21px;
 					letter-spacing: 0.154px;
 					max-height: 600px;
-					overflow: scroll;
+					overflow: auto;
 					margin: 32px 0;
 				}
 

--- a/panel-app/src/components/create-config/create-config.scss
+++ b/panel-app/src/components/create-config/create-config.scss
@@ -282,30 +282,30 @@
 				}
 			}
 		}
+	}
 
-		.config-action-btns {
-			// max-width: 530px;
-			display: flex;
-			justify-content: end;
-			padding: 8px 0px;
+	.config-action-btns {
+		// max-width: 530px;
+		display: flex;
+		justify-content: end;
+		padding: 8px 0px;
 
-			ion-button.cancel-btn::part(native),
-			ion-button.save-btn::part(native) {
-				border-radius: 8px;
-				border: 1px solid #1372ec;
-				margin-right: 8px;
-				width: 70px;
-				font-family: Gibson;
-				font-size: 14px;
-				font-style: normal;
-				font-weight: 300;
-				text-transform: capitalize;
-				--background-hover: #1372ec;
-				--background-hover-opacity: 1;
+		ion-button.cancel-btn::part(native),
+		ion-button.save-btn::part(native) {
+			border-radius: 8px;
+			border: 1px solid #1372ec;
+			margin-right: 8px;
+			width: 70px;
+			font-family: Gibson;
+			font-size: 14px;
+			font-style: normal;
+			font-weight: 300;
+			text-transform: capitalize;
+			--background-hover: #1372ec;
+			--background-hover-opacity: 1;
 
-				&:hover {
-					color: #fff;
-				}
+			&:hover {
+				color: #fff;
 			}
 		}
 	}

--- a/panel-app/src/components/create-config/create-config.tsx
+++ b/panel-app/src/components/create-config/create-config.tsx
@@ -133,6 +133,7 @@ export class CreateConfig {
 								<ion-img id="infoToken-img" src={infoToken}></ion-img>
 							</a>
 						</div>
+						<div class="header_sub-text">Start creating Web Scraper configuration for this file.</div>
 					</div>
 					<div class="header_btn">
 						<ion-button onClick={() => this.onDone()}>Done</ion-button>

--- a/panel-app/src/components/create-config/create-config.tsx
+++ b/panel-app/src/components/create-config/create-config.tsx
@@ -1,5 +1,5 @@
 import { Component, Listen, Prop, State, h } from '@stencil/core';
-import state, { addExcludedItem, addMetadataItem, addSubItem, addToRecentFiles, formatState, removeSubItem, resetStore, updateGlobalName, updateState } from '../store';
+import state, { SubItem, addExcludedItem, addMetadataItem, addSubItem, addToRecentFiles, formatState, removeSubItem, resetStore, updateGlobalName, updateState } from '../store';
 import { alertController, toastController } from '@ionic/core';
 import infoToken from '../../assets/icon/InfoToken.svg';
 
@@ -9,10 +9,10 @@ import infoToken from '../../assets/icon/InfoToken.svg';
 	shadow: false,
 })
 export class CreateConfig {
-	@Prop() fileName;
-	@Prop() triggerType;
+	@Prop() fileName: string;
+	@Prop() triggerType: 'new-file' | 'load-file';
 	@State() showSubItemConfig: boolean;
-	@State() subItem: {};
+	@State() subItem: SubItem;
 
 	@Listen('updateSubItemState')
 	hideSubItemConfig() {
@@ -21,7 +21,7 @@ export class CreateConfig {
 
 	renderExcludedItems() {
 		return state.exclude.map((item) => {
-			return <select-element-item type="excludeItem" selectorType={item.type} selector={item.path} uniqueId={item.id}></select-element-item>;
+			return <select-element-item type="excludeItem" selector={item} uniqueId={item.id}></select-element-item>;
 		});
 	}
 
@@ -29,7 +29,7 @@ export class CreateConfig {
 		const metadata = state.metadata;
 		return Object.keys(metadata).map((key) => {
 			const item = metadata[key];
-			return <select-element-item type="metadataItem" uniqueId={key} name={item.name} selectorType={item.type} selector={item.path} isBoolean={item.isBoolean}></select-element-item>;
+			return <select-element-item type="metadataItem" uniqueId={key} name={item.name} selector={item}></select-element-item>;
 		});
 	}
 

--- a/panel-app/src/components/file-explorer/file-explorer.tsx
+++ b/panel-app/src/components/file-explorer/file-explorer.tsx
@@ -1,4 +1,4 @@
-import { Component, State, h } from '@stencil/core';
+import { Component, Host, State, h } from '@stencil/core';
 import '@ionic/core';
 import noFileImage from '../../assets/icon/NotFoundImage.svg';
 import infoToken from '../../assets/icon/InfoToken.svg';
@@ -12,9 +12,8 @@ const RECENT_FILES_ITEM_NAME = '__Recent__Files__';
 	shadow: false,
 })
 export class FileExplorer {
+	@State() newFileName: string = '';
 	@State() showModal = false;
-	@State() fileName = '';
-	@State() triggerType: 'new-file' | 'load-file' = 'new-file'; // keeps track whether a new file is created or loaded
 	@State() fileList = [];
 	@State() recentFiles = [];
 
@@ -25,13 +24,16 @@ export class FileExplorer {
 
 		// save the default state right away
 		try {
-			chrome.storage.local.set({ [this.fileName]: JSON.stringify(formatState(), null, 2) });
-			this.recentFiles = await addToRecentFiles(this.fileName);
+			chrome.storage.local.set({ [this.newFileName]: JSON.stringify(formatState(), null, 2) });
+			this.recentFiles = await addToRecentFiles(this.newFileName);
+
+			state.currentFile = {
+				name: this.newFileName,
+				triggerType: 'new-file',
+			};
 		} catch (e) {
 			console.log(e);
 		}
-
-		state.redirectToConfig = true;
 	}
 
 	async componentWillRender() {
@@ -61,9 +63,8 @@ export class FileExplorer {
 					})}
 				</div>
 			);
-		} else {
-			return <ion-select-option class="no-files-option">Sorry, you haven’t created any files yet.</ion-select-option>;
 		}
+		return <ion-select-option class="no-files-option">Sorry, you haven’t created any files yet.</ion-select-option>;
 	}
 
 	renderRecentFiles() {
@@ -97,7 +98,13 @@ export class FileExplorer {
 				<div class="createFile-wrapper">
 					<div class="info-text">You have no files</div>
 					<div>
-						<ion-button class="create-file-btn" onClick={() => (this.showModal = true)}>
+						<ion-button
+							class="create-file-btn"
+							onClick={() => {
+								this.newFileName = '';
+								this.showModal = true;
+							}}
+						>
 							<ion-icon slot="start" name="add-circle-outline"></ion-icon>
 							Create a new file
 						</ion-button>
@@ -114,10 +121,11 @@ export class FileExplorer {
 		this.loadFile(event.target.value);
 	}
 
-	loadFile(fileName) {
-		this.fileName = fileName;
-		this.triggerType = 'load-file';
-		state.redirectToConfig = true;
+	loadFile(name) {
+		state.currentFile = {
+			name,
+			triggerType: 'load-file',
+		};
 	}
 
 	async removeFile(filename) {
@@ -145,8 +153,8 @@ export class FileExplorer {
 	}
 
 	render() {
-		return state.redirectToConfig === false ? (
-			<div id="file-explorer">
+		return (
+			<Host id="file-explorer">
 				<div class="header-section">
 					<div class="header_text-container">
 						<div class="header_title-text">
@@ -180,21 +188,19 @@ export class FileExplorer {
 						</div>
 						<div class="modal-content">
 							<div>Enter a name for your Web Scraper file.</div>
-							<ion-input fill="outline" placeholder="Name" onIonInput={(event) => (this.fileName = (event.target as HTMLIonInputElement).value as string)} value={this.fileName}></ion-input>
+							<ion-input fill="outline" placeholder="Name" onIonInput={(event) => (this.newFileName = (event.target as HTMLIonInputElement).value as string)} value={this.newFileName}></ion-input>
 						</div>
 						<div class="modal-footer">
 							<ion-button fill="outline" onClick={() => (this.showModal = false)}>
 								Cancel
 							</ion-button>
-							<ion-button fill="outline" onClick={() => this.onSaveClick()} disabled={!this.fileName}>
+							<ion-button fill="outline" onClick={() => this.onSaveClick()} disabled={!this.newFileName}>
 								Save
 							</ion-button>
 						</div>
 					</ion-modal>
 				</div>
-			</div>
-		) : (
-			<create-config fileName={this.fileName} triggerType={this.triggerType}></create-config>
+			</Host>
 		);
 	}
 }

--- a/panel-app/src/components/file-explorer/file-explorer.tsx
+++ b/panel-app/src/components/file-explorer/file-explorer.tsx
@@ -14,7 +14,7 @@ const RECENT_FILES_ITEM_NAME = '__Recent__Files__';
 export class FileExplorer {
 	@State() showModal = false;
 	@State() fileName = '';
-	@State() triggerType = 'new-file'; // keeps track whether a new file is created or loaded
+	@State() triggerType: 'new-file' | 'load-file' = 'new-file'; // keeps track whether a new file is created or loaded
 	@State() fileList = [];
 	@State() recentFiles = [];
 

--- a/panel-app/src/components/metadata-results/metadata-results.scss
+++ b/panel-app/src/components/metadata-results/metadata-results.scss
@@ -1,11 +1,8 @@
 .result-container {
 	margin-top: 8px;
 	width: 100%;
-	max-height: 208px;
 	border-radius: 8px;
 	border: 1px solid #e5e8e8;
-	display: flex;
-	overflow: scroll;
 
 	table {
 		width: inherit;

--- a/panel-app/src/components/select-element-item/select-element-item.tsx
+++ b/panel-app/src/components/select-element-item/select-element-item.tsx
@@ -1,6 +1,6 @@
 /*global chrome*/
 import { Component, h, Prop, State } from '@stencil/core';
-import { removeExcludedItem, removeMetadataItem, updateExcludedItem, updateMetadataItem } from '../store';
+import { removeExcludedItem, removeMetadataItem, Selector, updateExcludedItem, updateMetadataItem } from '../store';
 
 @Component({
 	tag: 'select-element-item',
@@ -11,15 +11,13 @@ export class SelectElementItem {
 	@Prop() uniqueId: string;
 	@Prop() type: string;
 	@Prop() name: string;
-	@Prop() selectorType: string;
-	@Prop() selector: string;
-	@Prop() isBoolean?: boolean;
+	@Prop() selector: Selector;
 	@State() selectorValidity;
 
-	async validateSelector(selector: string, selectorType: string) {
+	async validateSelector(selector: Selector) {
 		const response = await new Promise((resolve) => {
 			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'validate-selector', payload: { type: selectorType, selector: selector } }, null, (response) => {
+				chrome.tabs.sendMessage(tabs[0].id, { type: 'validate-selector', payload: selector }, null, (response) => {
 					resolve(response);
 				});
 			});
@@ -28,48 +26,48 @@ export class SelectElementItem {
 	}
 
 	handleSelectorTypeChange = () => {
-		const newSelectorType = this.selectorType === 'CSS' ? 'XPath' : 'CSS';
-		this.validateSelector(this.selector, newSelectorType);
+		const newSelectorType = this.selector.type === 'CSS' ? 'XPath' : 'CSS';
+		this.validateSelector({ ...this.selector, type: newSelectorType });
 
 		if (this.type === 'excludeItem') {
-			updateExcludedItem({ id: this.uniqueId, type: newSelectorType, path: this.selector }, { id: this.uniqueId, type: this.selectorType, path: this.selector });
+			updateExcludedItem({ ...this.selector, id: this.uniqueId, type: newSelectorType }, { ...this.selector, id: this.uniqueId });
 		} else {
-			updateMetadataItem({ id: this.uniqueId, name: this.name, type: newSelectorType, path: this.selector });
+			updateMetadataItem({ ...this.selector, id: this.uniqueId, name: this.name, type: newSelectorType });
 		}
 	};
 
 	handleSelectorChange = (event: CustomEvent) => {
 		console.log('handleSelectorChange: ', event);
-		const newSelector = event.detail.value;
-		this.validateSelector(newSelector, this.selectorType);
+		const newPath: string = event.detail.value;
+		this.validateSelector({ ...this.selector, path: newPath });
 
 		if (this.type === 'excludeItem') {
-			updateExcludedItem({ id: this.uniqueId, type: this.selectorType, path: newSelector }, { id: this.uniqueId, type: this.selectorType, path: this.selector });
+			updateExcludedItem({ ...this.selector, id: this.uniqueId, path: newPath }, { ...this.selector, id: this.uniqueId });
 		} else {
-			updateMetadataItem({ id: this.uniqueId, name: this.name, type: this.selectorType, path: newSelector });
+			updateMetadataItem({ ...this.selector, id: this.uniqueId, name: this.name, path: newPath });
 		}
 	};
 
 	handleNameChange = (event: CustomEvent) => {
 		const newName = event.detail.value;
-		updateMetadataItem({ id: this.uniqueId, name: newName, type: this.selectorType, path: this.selector });
+		updateMetadataItem({ ...this.selector, id: this.uniqueId, name: newName });
 	};
 
 	handleCheckboxChange = (event: CustomEvent) => {
 		const isChecked = event.detail.checked;
-		updateMetadataItem({ id: this.uniqueId, name: this.name, type: this.selectorType, path: this.selector, isBoolean: isChecked });
+		updateMetadataItem({ ...this.selector, id: this.uniqueId, name: this.name, isBoolean: isChecked });
 	};
 
 	removeItem = () => {
 		if (this.type === 'excludeItem') {
-			removeExcludedItem({ id: this.uniqueId, type: this.selectorType, path: this.selector });
+			removeExcludedItem({ ...this.selector, id: this.uniqueId });
 		} else {
 			removeMetadataItem(this.uniqueId);
 		}
 	};
 
 	componentWillRender() {
-		this.validateSelector(this.selector, this.selectorType);
+		this.validateSelector(this.selector);
 	}
 
 	render() {
@@ -88,20 +86,20 @@ export class SelectElementItem {
 					</div>
 				)}
 				<div>
-					<ion-input id="selector-type-input" class={cssClassForValidity} fill="outline" value={this.selectorType} onClick={this.handleSelectorTypeChange}></ion-input>
+					<ion-input id="selector-type-input" class={cssClassForValidity} fill="outline" value={this.selector.type} onClick={this.handleSelectorTypeChange}></ion-input>
 				</div>
 				<div style={{ flex: '2' }}>
 					<ion-input
 						class={this.type === 'excludeItem' ? 'selector-input' : 'metadata-selector-input'}
 						fill="outline"
-						value={this.selector}
+						value={this.selector.path}
 						placeholder="expression"
 						onIonInput={this.handleSelectorChange}
 					></ion-input>
 				</div>
 				{this.type === 'metadataItem' && (
 					<div>
-						<ion-checkbox onIonChange={this.handleCheckboxChange} checked={this.isBoolean}></ion-checkbox>
+						<ion-checkbox onIonChange={this.handleCheckboxChange} checked={this.selector.isBoolean}></ion-checkbox>
 						<ion-icon name="information-circle-outline"></ion-icon>
 					</div>
 				)}

--- a/panel-app/src/components/select-element-item/select-element-item.tsx
+++ b/panel-app/src/components/select-element-item/select-element-item.tsx
@@ -1,6 +1,7 @@
 /*global chrome*/
 import { Component, h, Prop, State } from '@stencil/core';
-import { removeExcludedItem, removeMetadataItem, Selector, updateExcludedItem, updateMetadataItem } from '../store';
+import { removeExcludedItem, removeMetadataItem, updateExcludedItem, updateMetadataItem } from '../store';
+import { Selector, SelectorType } from '../types';
 
 @Component({
 	tag: 'select-element-item',
@@ -12,7 +13,7 @@ export class SelectElementItem {
 	@Prop() type: string;
 	@Prop() name: string;
 	@Prop() selector: Selector;
-	@State() selectorValidity;
+	@State() selectorValidity: 'No element found' | 'Invalid' | 'Valid';
 
 	async validateSelector(selector: Selector) {
 		const response = await new Promise((resolve) => {
@@ -22,11 +23,11 @@ export class SelectElementItem {
 				});
 			});
 		});
-		this.selectorValidity = response;
+		this.selectorValidity = response as any;
 	}
 
 	handleSelectorTypeChange = () => {
-		const newSelectorType = this.selector.type === 'CSS' ? 'XPath' : 'CSS';
+		const newSelectorType: SelectorType = this.selector.type === 'CSS' ? 'XPATH' : 'CSS';
 		this.validateSelector({ ...this.selector, type: newSelectorType });
 
 		if (this.type === 'excludeItem') {

--- a/panel-app/src/components/store.ts
+++ b/panel-app/src/components/store.ts
@@ -1,33 +1,6 @@
 import { createStore } from '@stencil/store';
 import { v4 as uuidv4 } from 'uuid';
-
-export type Selector = {
-	type: 'CSS' | 'XPath';
-	path: string;
-	isBoolean?: boolean;
-};
-
-export type SelectorElement = Selector & { id?: string; };
-export type MetadataElement = SelectorElement & { name: string; };
-
-export type MetadataMap = {
-	[key: string]: MetadataElement;
-};
-
-export type SubItem = Selector & {
-	name: string;
-	exclude?: SelectorElement[];
-	metadata?: MetadataMap;
-};
-
-type ConfigState = {
-	name?: string;
-	redirectToConfig: boolean;
-	hasChanges: boolean;
-	exclude: SelectorElement[];
-	metadata: MetadataMap;
-	subItems: SubItem[];
-};
+import { ConfigState, MetadataMap, SelectorElement, SelectorType, SubItem } from './types';
 
 export function getId(): string {
 	let uniqueId = uuidv4();
@@ -35,7 +8,7 @@ export function getId(): string {
 }
 
 const { reset, state, onChange }: { reset: Function; state: ConfigState; onChange: Function; } = createStore({
-	redirectToConfig: false,
+	currentFile: null,
 	hasChanges: false,
 	exclude: [
 		{
@@ -245,7 +218,7 @@ function removeExcludedItem(item: SelectorElement) {
 	});
 }
 
-function addMetadataItem(item: { name: string; type: 'CSS' | 'XPath'; path: string; }) {
+function addMetadataItem(item: { name: string; type: SelectorType; path: string; }) {
 	state.metadata = { ...state.metadata, [getId()]: { name: item.name, type: item.type, path: item.path } };
 }
 
@@ -326,19 +299,20 @@ const addToRecentFiles = async (filename: string): Promise<string[]> => {
 
 export default state;
 export {
-	addToRecentFiles,
-	updateState,
-	updateGlobalName,
 	addExcludedItem,
-	removeExcludedItem,
 	addMetadataItem,
-	removeMetadataItem,
 	addSubItem,
-	removeSubItem,
-	updateExcludedItem,
-	updateMetadataItem,
-	updateSubItem,
+	addToRecentFiles,
 	formatState,
 	getMetadataResults,
+	removeExcludedItem,
+	removeMetadataItem,
+	removeSubItem,
 	resetStore,
+	updateExcludedItem,
+	updateGlobalName,
+	updateMetadataItem,
+	updateState,
+	updateSubItem,
 };
+

--- a/panel-app/src/components/sub-item-input-element/sub-item-input-element.tsx
+++ b/panel-app/src/components/sub-item-input-element/sub-item-input-element.tsx
@@ -10,11 +10,11 @@ export class SubItemInputElement {
 	@Event() updateSubItem: EventEmitter<any>;
 	@Prop() uniqueId: string;
 	@Prop() type: 'metadataItem' | 'subItem' | 'excludeItem';
-	@Prop() name: string;
-	@Prop() selector: Selector;
+	@Prop() selector: Selector | MetadataElement;
 	@State() selectorValidity;
 
-	updateState(action: 'update' | 'remove', newItem: SelectorElement | MetadataElement, oldItem: Selector = { type: 'CSS', path: '' }) {
+	updateState(action: 'update' | 'remove', newProps: Partial<SelectorElement | MetadataElement>, oldItem: Selector = { type: 'CSS', path: '' }) {
+		const newItem = { ...this.selector, ...newProps };
 		this.validateSelector(newItem);
 		this.updateSubItem.emit({ action: `${action}-${this.type}`, newItem, oldItem });
 	}
@@ -48,15 +48,9 @@ export class SubItemInputElement {
 						<ion-input
 							class={this.type === 'metadataItem' ? 'metadata-name-input name-input' : 'name-input'}
 							fill="outline"
-							value={this.name}
+							value={(this.selector as MetadataElement).name}
 							placeholder="Name"
-							onIonInput={(event) =>
-								this.updateState('update', {
-									...this.selector,
-									id: this.uniqueId,
-									name: event.target.value as string,
-								})
-							}
+							onIonInput={(event) => this.updateState('update', { id: this.uniqueId, name: event.target.value as string })}
 						></ion-input>
 					</div>
 				)}
@@ -66,7 +60,7 @@ export class SubItemInputElement {
 						fill="outline"
 						class={cssClassForValidity}
 						value={this.selector.type}
-						onClick={() => this.updateState('update', { ...this.selector, id: this.uniqueId, name: this.name, type: this.selector.type === 'CSS' ? 'XPATH' : 'CSS' }, this.selector)}
+						onClick={() => this.updateState('update', { id: this.uniqueId, type: this.selector.type === 'CSS' ? 'XPATH' : 'CSS' }, this.selector)}
 					></ion-input>
 				</div>
 				<div style={{ flex: '2' }}>
@@ -75,40 +69,17 @@ export class SubItemInputElement {
 						fill="outline"
 						value={this.selector.path}
 						placeholder="expression"
-						onIonInput={(event) => this.updateState('update', { ...this.selector, id: this.uniqueId, name: this.name, path: event.detail.value }, this.selector)}
+						onIonInput={(event) => this.updateState('update', { id: this.uniqueId, path: event.detail.value }, this.selector)}
 					></ion-input>
 				</div>
 				{this.type === 'metadataItem' && (
 					<div>
-						<ion-checkbox
-							checked={this.selector.isBoolean}
-							onIonChange={(event) =>
-								this.updateState(
-									'update',
-									{
-										...this.selector,
-										id: this.uniqueId,
-										name: this.name,
-										isBoolean: event.detail.checked,
-									},
-									this.selector
-								)
-							}
-						></ion-checkbox>
+						<ion-checkbox checked={this.selector.isBoolean} onIonChange={(event) => this.updateState('update', { id: this.uniqueId, isBoolean: event.detail.checked }, this.selector)}></ion-checkbox>
 						<ion-icon name="information-circle-outline"></ion-icon>
 					</div>
 				)}
 				{!(this.type === 'subItem') && (
-					<div
-						style={{ cursor: 'pointer' }}
-						onClick={() =>
-							this.updateState('remove', {
-								...this.selector,
-								id: this.uniqueId,
-								name: this.name,
-							})
-						}
-					>
+					<div style={{ cursor: 'pointer' }} onClick={() => this.updateState('remove', { id: this.uniqueId })}>
 						<ion-icon name="remove-circle-outline" size="small" color="primary"></ion-icon>
 					</div>
 				)}

--- a/panel-app/src/components/sub-item-input-element/sub-item-input-element.tsx
+++ b/panel-app/src/components/sub-item-input-element/sub-item-input-element.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, Event, EventEmitter, State } from '@stencil/core';
-import { SelectorElement, Selector, MetadataElement } from '../store';
+import { SelectorElement, Selector, MetadataElement } from '../types';
 
 @Component({
 	tag: 'sub-item-input-element',
@@ -66,7 +66,7 @@ export class SubItemInputElement {
 						fill="outline"
 						class={cssClassForValidity}
 						value={this.selector.type}
-						onClick={() => this.updateState('update', { ...this.selector, id: this.uniqueId, name: this.name, type: this.selector.type === 'CSS' ? 'XPath' : 'CSS' }, this.selector)}
+						onClick={() => this.updateState('update', { ...this.selector, id: this.uniqueId, name: this.name, type: this.selector.type === 'CSS' ? 'XPATH' : 'CSS' }, this.selector)}
 					></ion-input>
 				</div>
 				<div style={{ flex: '2' }}>

--- a/panel-app/src/components/subitem-edit-config/subitem-edit-config.scss
+++ b/panel-app/src/components/subitem-edit-config/subitem-edit-config.scss
@@ -28,7 +28,7 @@
 	}
 
 	.subItem-box {
-		padding: 24px 24px 0 24px;
+		padding: 24px;
 		margin-top: 8px;
 		border-radius: 8px;
 		border: 1px solid #e5e8e8;
@@ -76,8 +76,6 @@
 		letter-spacing: 0.042px;
 		cursor: pointer;
 		width: fit-content;
-		margin-top: 6px;
-		margin-bottom: 14px;
 
 		ion-icon {
 			margin: -2px 8px 0 0;

--- a/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
+++ b/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
@@ -1,6 +1,7 @@
-import { Component, Prop, h, Event, EventEmitter, State, Listen } from '@stencil/core';
-import state, { SelectorElement, MetadataMap, getId, SubItem } from '../store';
 import { toastController } from '@ionic/core';
+import { Component, Event, EventEmitter, Listen, Prop, State, h } from '@stencil/core';
+import state, { getId } from '../store';
+import { MetadataMap, SelectorElement, SubItem } from '../types';
 
 @Component({
 	tag: 'subitem-edit-config',

--- a/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
+++ b/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
@@ -136,12 +136,12 @@ export class SubitemEditConfig {
 	renderMetadataItems() {
 		return Object.keys(this.metadata).map((key) => {
 			const item = this.metadata[key];
-			return <sub-item-input-element uniqueId={key} type="metadataItem" name={item.name} selector={item}></sub-item-input-element>;
+			return <sub-item-input-element uniqueId={key} type="metadataItem" selector={item}></sub-item-input-element>;
 		});
 	}
 
 	renderSubItemInfo() {
-		return <sub-item-input-element type="subItem" name={this.subItemState.name} selector={this.subItemState}></sub-item-input-element>;
+		return <sub-item-input-element type="subItem" selector={this.subItemState}></sub-item-input-element>;
 	}
 
 	render() {

--- a/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
+++ b/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
@@ -1,5 +1,5 @@
 import { Component, Prop, h, Event, EventEmitter, State, Listen } from '@stencil/core';
-import state, { ElementsToExclude, Metadata, getId } from '../store';
+import state, { SelectorElement, MetadataMap, getId, SubItem } from '../store';
 import { toastController } from '@ionic/core';
 
 @Component({
@@ -10,9 +10,9 @@ import { toastController } from '@ionic/core';
 export class SubitemEditConfig {
 	@Prop() subItem: {};
 	@Event() updateSubItemState: EventEmitter<any>;
-	@State() excludedItems: ElementsToExclude[];
-	@State() metadata: Metadata;
-	@State() subItemState: { name: ''; type: ''; path: '' };
+	@State() excludedItems: SelectorElement[];
+	@State() metadata: MetadataMap;
+	@State() subItemState: SubItem;
 	selectorValidity;
 
 	@Listen('updateSubItem')
@@ -32,16 +32,15 @@ export class SubitemEditConfig {
 	}
 
 	onSave() {
-		state.subItems = state.subItems.map((item) => {
+		state.subItems = state.subItems.map((item: SubItem): SubItem => {
 			if (item.name === this.subItem['name']) {
 				return {
 					...this.subItemState,
 					exclude: this.excludedItems,
 					metadata: this.metadata,
 				};
-			} else {
-				return item;
 			}
+			return item;
 		});
 		this.updateSubItemState.emit();
 		toastController
@@ -76,11 +75,11 @@ export class SubitemEditConfig {
 
 	updateState(action: string, newItem, oldItem = { type: '', path: '' }) {
 		switch (action) {
-			case 'add-excludedItem': {
+			case 'add-excludeItem': {
 				this.excludedItems = [...this.excludedItems, { ...newItem, id: getId() }];
 				break;
 			}
-			case 'remove-excludedItem': {
+			case 'remove-excludeItem': {
 				this.excludedItems = this.excludedItems.filter((excludedItem) => {
 					return excludedItem.id !== newItem.id;
 				});
@@ -98,7 +97,7 @@ export class SubitemEditConfig {
 				this.metadata = rest;
 				break;
 			}
-			case 'update-excludedItem': {
+			case 'update-excludeItem': {
 				this.excludedItems = this.excludedItems.map((excludedItem) => {
 					if (excludedItem.id === newItem.id) {
 						chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -129,19 +128,19 @@ export class SubitemEditConfig {
 
 	renderExcludedItems() {
 		return this.excludedItems.map((item) => {
-			return <sub-item-input-element uniqueId={item.id} type="excludeItem" selectorType={item.type} selector={item.path}></sub-item-input-element>;
+			return <sub-item-input-element uniqueId={item.id} type="excludeItem" selector={item}></sub-item-input-element>;
 		});
 	}
 
 	renderMetadataItems() {
 		return Object.keys(this.metadata).map((key) => {
 			const item = this.metadata[key];
-			return <sub-item-input-element uniqueId={key} type="metadataItem" name={item.name} selectorType={item.type} selector={item.path} isBoolean={item.isBoolean}></sub-item-input-element>;
+			return <sub-item-input-element uniqueId={key} type="metadataItem" name={item.name} selector={item}></sub-item-input-element>;
 		});
 	}
 
 	renderSubItemInfo() {
-		return <sub-item-input-element type="subItem" name={this.subItemState.name} selectorType={this.subItemState.type} selector={this.subItemState.path}></sub-item-input-element>;
+		return <sub-item-input-element type="subItem" name={this.subItemState.name} selector={this.subItemState}></sub-item-input-element>;
 	}
 
 	render() {
@@ -160,7 +159,7 @@ export class SubitemEditConfig {
 						<div class="subItem-edit-text">Elements to exlude</div>
 						<div class="subItem-box">
 							<div id="select-subItem__wrapper">{this.renderExcludedItems()}</div>
-							<div class="add-rule" onClick={() => this.updateState('add-excludedItem', { type: 'CSS', path: '' })}>
+							<div class="add-rule" onClick={() => this.updateState('add-excludeItem', { type: 'CSS', path: '' })}>
 								<ion-icon name="add-circle-outline" size="small" color="primary"></ion-icon>
 								<span>Add Rule</span>
 							</div>

--- a/panel-app/src/components/types.ts
+++ b/panel-app/src/components/types.ts
@@ -1,0 +1,33 @@
+
+export type SelectorType = 'CSS' | 'XPATH';
+
+export type Selector = {
+  type: SelectorType;
+  path: string;
+  isBoolean?: boolean;
+};
+
+export type SelectorElement = Selector & { id?: string; };
+export type MetadataElement = SelectorElement & { name: string; };
+
+export type MetadataMap = {
+  [key: string]: MetadataElement;
+};
+
+export type SubItem = Selector & {
+  name: string;
+  exclude?: SelectorElement[];
+  metadata?: MetadataMap;
+};
+
+export type ConfigState = {
+  name?: string;
+  currentFile: {
+    name: string;
+    triggerType: 'new-file' | 'load-file',
+  } | null;
+  hasChanges: boolean;
+  exclude: SelectorElement[];
+  metadata: MetadataMap;
+  subItems: SubItem[];
+};


### PR DESCRIPTION
I brought back the JavaScript classes from V1's content-script.js : `RulePath`, `CssRule`, and `XPathRule`. They were already correctly handling the different selectors and their "extensions" like `::text` and `::attr()`.
And I like how these classes allow us to not care about CSS or XPath types when dealing with "elements". 

That part fixed the use of `::attr()`. 

I also took the opportunity to define a few more types in TypeScript. 
Then I got carried in a small refactoring. When defining a type for "Selector" as an object with `{type: 'CSS'|'XPATH', path: string}` I updated where elements were padding them separately and used the selector type only. 

I also split <create-config> from under <file-explorer> and did the logic in <app-root> instead. 
I moved the handling of "current file" from `FileExplorer.fileName` into `state.currentFile = {name: string, triggerType: string}`.

I started to think about fixing the scroll bars behaviour. But I will leave it for another PR. Like you mentioned, we probably need to get rid of the ion-tabs. 

I would gladly go through these changes with you if you like. 