### PR TITLE
V2 Added fix for styles on exclude items not getting removed and fixes for subitems

### DIFF
--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -283,10 +283,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'remove-exclude-selector') {
     const { item, parentSelector } = message.payload;
     try {
-      const elements = createRule(item, null, null, parentSelector).getElements(true);
-      elements?.forEach(element => {
-        element.classList?.remove('web-scraper-helper-exclude');
-      });
+      let parents = getParentsElements(parentSelector);
+      parents.forEach(parent => {
+        const elements = createRule(item, null, null, parent).getElements(true);
+        elements?.forEach(element => {
+          element.classList?.remove('web-scraper-helper-exclude');
+        });
+      })
     } catch (e) {
       console.log(e);
     }
@@ -338,12 +341,14 @@ function applyStylesToElements(newItem, oldItem = null, parentSelector = null) {
 
 function removePreviouslyExcludedStyles(parentSelector = null) {
   try {
-    let parent = parentSelector ? document.querySelector(parentSelector) : document;
-    parent.querySelectorAll('.web-scraper-helper-exclude').forEach(e => {
-      if (e && e.classList) {
-        e.classList.remove('web-scraper-helper-exclude');
-      }
-    });
+    let parents = getParentsElements(parentSelector);
+    parents.forEach(parent => {
+      parent.querySelectorAll('.web-scraper-helper-exclude').forEach(e => {
+        if (e && e.classList) {
+          e.classList.remove('web-scraper-helper-exclude');
+        }
+      });
+    })
   } catch (e) {
     console.log(e);
   }

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -311,6 +311,27 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log('metadata-result-array', message, results);
     sendResponse(results);
   }
+  if (message.type === 'update-parentSelector-style') {
+    const { newSelector, oldSelector } = message.payload;
+    if (oldSelector && oldSelector.path !== newSelector.path) {
+      const oldElements = createRule(oldSelector, null, null, null).getElements(true);
+      oldElements?.forEach(element => {
+        element.classList.remove('web-scrapper-subItem-parentSelector');
+      });
+    }
+
+    const newElements = createRule(newSelector, null, null, null).getElements(true);
+    newElements?.forEach(element => {
+      element.classList.add('web-scrapper-subItem-parentSelector');
+    });
+  }
+  if (message.type === 'remove-parentSelector-style') {
+    const { parentSelector } = message.payload;
+    const parents = createRule(parentSelector, null, null, null).getElements(true);
+    parents?.forEach(element => {
+      element.classList.remove('web-scraper-subItem-parentSelector');
+    });
+  }
 });
 
 function applyStylesToElements(newItem, oldItem = null, parentSelector = null) {

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -273,12 +273,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     sendResponse(response);
   }
   if (message.type === 'update-excludeItem-onLoad') {
-    const { exclude } = message.payload;
+    const { exclude, subItems } = message.payload;
     exclude.length && exclude.map((element) => applyStylesToElements(element));
-  }
-  if (message.type === 'update-excludeSubItem-onLoad') {
-    const { exclude, parentSelector } = message.payload;
-    exclude.length && exclude.map((element) => applyStylesToElements(element, null, parentSelector));
+    subItems.map(subItem => {
+      subItem.exclude.length && subItem.exclude.map((element) => applyStylesToElements(element, null, { type: subItem.type, path: subItem.path }));
+    })
   }
   if (message.type === 'remove-exclude-selector') {
     const { item, parentSelector } = message.payload;
@@ -295,8 +294,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
   }
   if (message.type === 'remove-excluded-on-file-close') {
-    const { parentSelector } = message.payload;
-    removePreviouslyExcludedStyles(parentSelector);
+    removePreviouslyExcludedStyles();
   }
   if (message.type === 'metadata-results') {
     const { metadata, parentSelector } = message.payload;
@@ -339,16 +337,13 @@ function applyStylesToElements(newItem, oldItem = null, parentSelector = null) {
   }
 }
 
-function removePreviouslyExcludedStyles(parentSelector = null) {
+function removePreviouslyExcludedStyles() {
   try {
-    let parents = getParentsElements(parentSelector);
-    parents.forEach(parent => {
-      parent.querySelectorAll('.web-scraper-helper-exclude').forEach(e => {
-        if (e && e.classList) {
-          e.classList.remove('web-scraper-helper-exclude');
-        }
-      });
-    })
+    document.querySelectorAll('.web-scraper-helper-exclude').forEach(e => {
+      if (e && e.classList) {
+        e.classList.remove('web-scraper-helper-exclude');
+      }
+    });
   } catch (e) {
     console.log(e);
   }

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -6,7 +6,7 @@ class RulePath {
   constructor(spec, title, subItemName, container) {
     this.path = spec.path;
     this.isBoolean = spec.isBoolean ? true : false;
-    if (title !== undefined) {
+    if (title) {
       this.title = title;
     } else if (spec.name) {
       this.title = spec.name;
@@ -277,7 +277,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     exclude.length && exclude.map((element) => applyStylesToElements(element));
     subItems.map(subItem => {
       subItem.exclude.length && subItem.exclude.map((element) => applyStylesToElements(element, null, { type: subItem.type, path: subItem.path }));
-    })
+    });
   }
   if (message.type === 'remove-exclude-selector') {
     const { item, parentSelector } = message.payload;
@@ -288,7 +288,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         elements?.forEach(element => {
           element.classList?.remove('web-scraper-helper-exclude');
         });
-      })
+      });
     } catch (e) {
       console.log(e);
     }
@@ -314,21 +314,19 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'update-parentSelector-style') {
     const { newSelector, oldSelector } = message.payload;
     if (oldSelector && oldSelector.path !== newSelector.path) {
-      const oldElements = createRule(oldSelector, null, null, null).getElements(true);
+      const oldElements = createRule(oldSelector).getElements(true);
       oldElements?.forEach(element => {
-        element.classList.remove('web-scrapper-subItem-parentSelector');
+        element.classList.remove('web-scraper-subItem-parentSelector');
       });
     }
 
-    const newElements = createRule(newSelector, null, null, null).getElements(true);
+    const newElements = createRule(newSelector).getElements(true);
     newElements?.forEach(element => {
-      element.classList.add('web-scrapper-subItem-parentSelector');
+      element.classList.add('web-scraper-subItem-parentSelector');
     });
   }
   if (message.type === 'remove-parentSelector-style') {
-    const { parentSelector } = message.payload;
-    const parents = createRule(parentSelector, null, null, null).getElements(true);
-    parents?.forEach(element => {
+    document.querySelectorAll('.web-scraper-subItem-parentSelector').forEach(element => {
       element.classList.remove('web-scraper-subItem-parentSelector');
     });
   }
@@ -360,9 +358,9 @@ function applyStylesToElements(newItem, oldItem = null, parentSelector = null) {
 
 function removePreviouslyExcludedStyles() {
   try {
-    document.querySelectorAll('.web-scraper-helper-exclude').forEach(e => {
+    document.querySelectorAll('.web-scraper-helper-exclude, .web-scraper-subItem-parentSelector').forEach(e => {
       if (e && e.classList) {
-        e.classList.remove('web-scraper-helper-exclude');
+        e.classList.remove('web-scraper-helper-exclude', 'web-scraper-subItem-parentSelector');
       }
     });
   } catch (e) {

--- a/chrome_extension/css/inject.css
+++ b/chrome_extension/css/inject.css
@@ -1,7 +1,7 @@
 .web-scraper-helper-exclude {
-  opacity: 0.1 !important;
+	opacity: 0.1 !important;
 }
 
-.web-scrapper-subItem-parentSelector {
-  border: 1px solid red;
+.web-scraper-subItem-parentSelector {
+	border: 3px dashed red !important;
 }

--- a/chrome_extension/css/inject.css
+++ b/chrome_extension/css/inject.css
@@ -1,3 +1,7 @@
 .web-scraper-helper-exclude {
   opacity: 0.1 !important;
 }
+
+.web-scrapper-subItem-parentSelector {
+  border: 1px solid red;
+}

--- a/panel-app/src/components/app-root/app-root.tsx
+++ b/panel-app/src/components/app-root/app-root.tsx
@@ -17,7 +17,7 @@ export class AppRoot {
 					<div class="header-container">
 						<ion-img id="coveo-logo-img" src={logo}></ion-img>
 						<div id="header-separator"></div>
-						<div class="top-bar-text">Web Scrapper</div>
+						<div class="top-bar-text">Web Scraper</div>
 					</div>
 				</header>
 

--- a/panel-app/src/components/create-config/create-config.tsx
+++ b/panel-app/src/components/create-config/create-config.tsx
@@ -36,7 +36,7 @@ export class CreateConfig {
 		state.currentFile = null;
 		resetStore();
 		chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-			chrome.tabs.sendMessage(tabs[0].id, { type: 'remove-excluded-on-file-close', payload: { parentSelector: null } });
+			chrome.tabs.sendMessage(tabs[0].id, { type: 'remove-excluded-on-file-close' });
 		});
 	}
 
@@ -103,7 +103,7 @@ export class CreateConfig {
 				await addToRecentFiles(fileName);
 			} else {
 				chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-					chrome.tabs.sendMessage(tabs[0].id, { type: 'update-excludeItem-onLoad', payload: { exclude: state.exclude } });
+					chrome.tabs.sendMessage(tabs[0].id, { type: 'update-excludeItem-onLoad', payload: { exclude: state.exclude, subItems: state.subItems } });
 				});
 			}
 		} catch (e) {

--- a/panel-app/src/components/store.ts
+++ b/panel-app/src/components/store.ts
@@ -7,7 +7,7 @@ export function getId(): string {
 	return `uid-${uniqueId}-${Date.now()}`;
 }
 
-const { reset, state, onChange }: { reset: Function; state: ConfigState; onChange: Function; } = createStore({
+const { reset, state, onChange }: { reset: Function; state: ConfigState; onChange: Function } = createStore({
 	currentFile: null,
 	hasChanges: false,
 	exclude: [
@@ -128,7 +128,7 @@ function updateState(newState, hasChanges?: boolean): boolean {
 
 			// add opacity to the elements onLoad
 			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'update-excludeItem-onLoad', payload: { exclude: state.exclude } });
+				chrome.tabs.sendMessage(tabs[0].id, { type: 'update-excludeItem-onLoad', payload: { exclude: state.exclude, subItems: state.subItems } });
 			});
 
 			if (hasChanges !== undefined) {
@@ -218,7 +218,7 @@ function removeExcludedItem(item: SelectorElement) {
 	});
 }
 
-function addMetadataItem(item: { name: string; type: SelectorType; path: string; }) {
+function addMetadataItem(item: { name: string; type: SelectorType; path: string }) {
 	state.metadata = { ...state.metadata, [getId()]: { name: item.name, type: item.type, path: item.path } };
 }
 
@@ -249,7 +249,7 @@ function removeSubItem(itemName: string) {
 	});
 }
 
-function updateMetadataItem(newItem: { id: string; name: string; type: string; path: string; isBoolean?: boolean; }) {
+function updateMetadataItem(newItem: { id: string; name: string; type: string; path: string; isBoolean?: boolean }) {
 	state.metadata = Object.keys(state.metadata).reduce((acc, key) => {
 		if (key === newItem.id) {
 			acc[key] = { name: newItem.name, type: newItem.type, path: newItem.path, ...(newItem.isBoolean && { isBoolean: newItem.isBoolean }) };
@@ -315,4 +315,3 @@ export {
 	updateState,
 	updateSubItem,
 };
-

--- a/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
+++ b/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
@@ -25,7 +25,7 @@ export class SubitemEditConfig {
 	removeExcludeStyleOnClose() {
 		try {
 			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'remove-excluded-on-file-close', payload: { parentSelector: this.subItemState.path } });
+				chrome.tabs.sendMessage(tabs[0].id, { type: 'remove-excluded-on-file-close', payload: { parentSelector: this.subItemState } });
 			});
 		} catch (e) {
 			console.log(e);
@@ -67,7 +67,7 @@ export class SubitemEditConfig {
 		this.metadata = this.subItem['metadata'];
 		try {
 			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'update-excludeSubItem-onLoad', payload: { exclude: this.excludedItems, parentSelector: this.subItemState.path } });
+				chrome.tabs.sendMessage(tabs[0].id, { type: 'update-excludeSubItem-onLoad', payload: { exclude: this.excludedItems, parentSelector: this.subItemState } });
 			});
 		} catch (e) {
 			console.log(e);
@@ -85,7 +85,7 @@ export class SubitemEditConfig {
 					return excludedItem.id !== newItem.id;
 				});
 				chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-					chrome.tabs.sendMessage(tabs[0].id, { type: 'remove-exclude-selector', payload: { item: newItem, parentSelector: this.subItemState.path } });
+					chrome.tabs.sendMessage(tabs[0].id, { type: 'remove-exclude-selector', payload: { item: newItem, parentSelector: this.subItemState } });
 				});
 				break;
 			}
@@ -103,7 +103,7 @@ export class SubitemEditConfig {
 					if (excludedItem.id === newItem.id) {
 						chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
 							console.log('updateExcludedSubItem: ', newItem.path, oldItem.path);
-							chrome.tabs.sendMessage(tabs[0].id, { type: 'exclude-selector', payload: { newItem: newItem, oldItem: oldItem, parentSelector: this.subItemState.path } });
+							chrome.tabs.sendMessage(tabs[0].id, { type: 'exclude-selector', payload: { newItem: newItem, oldItem: oldItem, parentSelector: this.subItemState } });
 						});
 						return { id: newItem.id, type: newItem.type, path: newItem.path };
 					} else {

--- a/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
+++ b/panel-app/src/components/subitem-edit-config/subitem-edit-config.tsx
@@ -22,16 +22,6 @@ export class SubitemEditConfig {
 		this.updateState(action, newItem, oldItem);
 	}
 
-	removeExcludeStyleOnClose() {
-		try {
-			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'remove-excluded-on-file-close', payload: { parentSelector: this.subItemState } });
-			});
-		} catch (e) {
-			console.log(e);
-		}
-	}
-
 	onSave() {
 		state.subItems = state.subItems.map((item: SubItem): SubItem => {
 			if (item.name === this.subItem['name']) {
@@ -53,25 +43,16 @@ export class SubitemEditConfig {
 			.then((toast) => {
 				toast.present();
 			});
-		this.removeExcludeStyleOnClose();
 	}
 
 	onCancel() {
 		this.updateSubItemState.emit();
-		this.removeExcludeStyleOnClose();
 	}
 
 	componentWillLoad() {
 		this.subItemState = { name: this.subItem['name'], type: this.subItem['type'], path: this.subItem['path'] };
 		this.excludedItems = this.subItem['exclude'];
 		this.metadata = this.subItem['metadata'];
-		try {
-			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'update-excludeSubItem-onLoad', payload: { exclude: this.excludedItems, parentSelector: this.subItemState } });
-			});
-		} catch (e) {
-			console.log(e);
-		}
 	}
 
 	updateState(action: string, newItem, oldItem = { type: '', path: '' }) {


### PR DESCRIPTION
The styles on the excluded items were not getting removed for subItem and also on file close. This PR includes the fix for the same
While at it, I made the change for subItems:  exclude items have the styles applied on file open now rather than opening each subItem specifically.
Also added a red border around the subItem selector when each subItem file is opened