### PR TITLE
Move chrome.tabs.* calls under sendMessageToContentScript()

### DIFF
--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -269,7 +269,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     } catch (e) {
       response = 'Invalid';
     }
-    console.log('validate-selector', message, response);
+    // console.log('validate-selector', message, response);
     sendResponse(response);
   }
   if (message.type === 'update-excludeItem-onLoad') {
@@ -308,7 +308,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         results.push({ "name": name, "values": rule.getElements() });
       });
     }
-    console.log('metadata-result-array', message, results);
+    // console.log('metadata-result-array', message, results);
     sendResponse(results);
   }
   if (message.type === 'update-parentSelector-style') {

--- a/panel-app/src/components/select-element-item/select-element-item.tsx
+++ b/panel-app/src/components/select-element-item/select-element-item.tsx
@@ -33,7 +33,6 @@ export class SelectElementItem {
 	};
 
 	handleSelectorChange = (event: CustomEvent) => {
-		console.log('handleSelectorChange: ', event);
 		const newPath: string = event.detail.value;
 		this.validateSelector({ ...this.selector, path: newPath });
 

--- a/panel-app/src/components/select-element-item/select-element-item.tsx
+++ b/panel-app/src/components/select-element-item/select-element-item.tsx
@@ -1,6 +1,6 @@
 /*global chrome*/
 import { Component, h, Prop, State } from '@stencil/core';
-import { removeExcludedItem, removeMetadataItem, updateExcludedItem, updateMetadataItem } from '../store';
+import { removeExcludedItem, removeMetadataItem, sendMessageToContentScript, updateExcludedItem, updateMetadataItem } from '../store';
 import { Selector, SelectorType } from '../types';
 
 @Component({
@@ -15,15 +15,10 @@ export class SelectElementItem {
 	@Prop() selector: Selector;
 	@State() selectorValidity: 'No element found' | 'Invalid' | 'Valid';
 
-	async validateSelector(selector: Selector) {
-		const response = await new Promise((resolve) => {
-			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'validate-selector', payload: selector }, null, (response) => {
-					resolve(response);
-				});
-			});
+	validateSelector(selector: Selector) {
+		sendMessageToContentScript({ type: 'validate-selector', payload: selector }, (response) => {
+			this.selectorValidity = response as any;
 		});
-		this.selectorValidity = response as any;
 	}
 
 	handleSelectorTypeChange = () => {

--- a/panel-app/src/components/sub-item-input-element/sub-item-input-element.tsx
+++ b/panel-app/src/components/sub-item-input-element/sub-item-input-element.tsx
@@ -1,5 +1,6 @@
 import { Component, Prop, h, Event, EventEmitter, State } from '@stencil/core';
 import { SelectorElement, Selector, MetadataElement } from '../types';
+import { sendMessageToContentScript } from '../store';
 
 @Component({
 	tag: 'sub-item-input-element',
@@ -19,15 +20,10 @@ export class SubItemInputElement {
 		this.updateSubItem.emit({ action: `${action}-${this.type}`, newItem, oldItem });
 	}
 
-	async validateSelector(selector: Selector) {
-		const response = await new Promise((resolve) => {
-			chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-				chrome.tabs.sendMessage(tabs[0].id, { type: 'validate-selector', payload: selector }, null, (response) => {
-					resolve(response);
-				});
-			});
+	validateSelector(selector: Selector) {
+		sendMessageToContentScript({ type: 'validate-selector', payload: selector }, (response) => {
+			this.selectorValidity = response;
 		});
-		this.selectorValidity = response;
 	}
 
 	componentWillLoad() {


### PR DESCRIPTION
I created the function `sendMessageToContentScript()` to put all the logic for using `chrome.tabs.*` into one function, since they were all using the same properties. 
