### PR TITLE
LAB-749 Fixes based on Ui design review

### DIFF
--- a/panel-app/src/components/select-element-item/select-element-item.scss
+++ b/panel-app/src/components/select-element-item/select-element-item.scss
@@ -18,8 +18,6 @@
 		line-height: 21px;
 		letter-spacing: 0.042px;
 		--border-radius: 8px;
-		--highlight-color: transparent;
-		--highlight-color-focused: transparent;
 		cursor: pointer;
 
 		&:hover,

--- a/panel-app/src/components/sub-item-input-element/sub-item-input-element.scss
+++ b/panel-app/src/components/sub-item-input-element/sub-item-input-element.scss
@@ -19,8 +19,6 @@
 		line-height: 21px;
 		letter-spacing: 0.042px;
 		--border-radius: 8px;
-		--highlight-color: transparent;
-		--highlight-color-focused: transparent;
 		cursor: pointer;
 
 		&:hover,


### PR DESCRIPTION
On rare instances, when we click on CSS/XPATH to choose one of them , the outline disappears making it look disabled .
This PR includes the fix for the same.