### PR TITLE
LAB-749 Fix for backdrop not covering full height on scroll

### DIFF
--- a/panel-app/src/global/app.scss
+++ b/panel-app/src/global/app.scss
@@ -14,6 +14,10 @@ body {
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
+body:has(ion-modal.show-modal){
+	overflow: hidden;
+}
+
 ion-popover .no-files-option {
 	color: #565b66;
 	font-family: Gibson;


### PR DESCRIPTION
During UI Review, it was noticed that during modal popup, when scrolling was possible - the backdrop was not covering the full height. Screenshot below:
![Screen Shot 2023-12-05 at 11 58 25 AM](https://github.com/coveo-labs/web-scraper-helper/assets/86019421/d2230ff1-6985-49f1-ab14-7eba4a376a24)

I tried tweaking the height for Ion-modal and ion-backdrop to take the height of the full panel but looks like a limitation on the github issues for ion components. So I simply prevent scrolling when modal is shown