### PR TITLE
Load Amplitude key from .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .eslintcache
+.env
 .stencil
 .DS_store
 node_modules

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Web Scraper Helper for Coveo Web Sources",
   "short_name": "Web Scraper Helper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Helper to quickly create and test web scraping configurations for Coveo Cloud V2 sources.",
   "icons": {
     "16": "icons/16.png",

--- a/panel-app/.env.example
+++ b/panel-app/.env.example
@@ -1,0 +1,1 @@
+AMPLITUDE_KEY=-amplitude-key-

--- a/panel-app/package-lock.json
+++ b/panel-app/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "web-scraper-helper-panel",
 			"version": "2.0.1",
 			"dependencies": {
+				"@amplitude/analytics-browser": "^2.3.6",
 				"@types/babel__traverse": "^7.20.4",
 				"uuid": "^9.0.1"
 			},
@@ -23,6 +24,70 @@
 				"jest-cli": "^29.7.0",
 				"puppeteer": "^21.6.0",
 				"rollup-plugin-dotenv": "0.5.0"
+			}
+		},
+		"node_modules/@amplitude/analytics-browser": {
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.3.6.tgz",
+			"integrity": "sha512-P8N19qeoSDPO0crdQwa2yi+T0/UT4v9FqZrtXF3JW4kgxu++dTW/QkQ6bsv29EPg2N54xyr9IOt98q9EkZbA7A==",
+			"dependencies": {
+				"@amplitude/analytics-client-common": "^2.0.9",
+				"@amplitude/analytics-core": "^2.1.2",
+				"@amplitude/analytics-types": "^2.3.1",
+				"@amplitude/plugin-page-view-tracking-browser": "^2.0.16",
+				"@amplitude/plugin-web-attribution-browser": "^2.0.16",
+				"tslib": "^2.4.1"
+			}
+		},
+		"node_modules/@amplitude/analytics-client-common": {
+			"version": "2.0.9",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.0.9.tgz",
+			"integrity": "sha512-2CSUMY60Jemks/XVro8ikuHBebENzb+IxnUz4YPx5fmBPW7QW+ysmD+LgECeLhv9jWIQoDhuciscPLuRENKerA==",
+			"dependencies": {
+				"@amplitude/analytics-connector": "^1.4.8",
+				"@amplitude/analytics-core": "^2.1.2",
+				"@amplitude/analytics-types": "^2.3.1",
+				"tslib": "^2.4.1"
+			}
+		},
+		"node_modules/@amplitude/analytics-connector": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
+			"integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
+		},
+		"node_modules/@amplitude/analytics-core": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.1.2.tgz",
+			"integrity": "sha512-vRkP2HHh43u7vilpUrP3Q8o/TMJ6U2B7nxPV9/aUS5V/im0Zigq4mPcn5uNY7FuTwsJM3zzRxK9J2WvfdG5bqA==",
+			"dependencies": {
+				"@amplitude/analytics-types": "^2.3.1",
+				"tslib": "^2.4.1"
+			}
+		},
+		"node_modules/@amplitude/analytics-types": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.3.1.tgz",
+			"integrity": "sha512-yojBG20qvph0rpCJKb4i/FJa+otqLINEwv//hfzvjnCOcPPyS0YscI8oiRBM0rG7kZIDgaL9a6jPwkqK4ACmcw=="
+		},
+		"node_modules/@amplitude/plugin-page-view-tracking-browser": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.16.tgz",
+			"integrity": "sha512-o9YlpXm0BcnUEK47K5xAqEa/q7DOsKGb6F35gF5iGUFXTtBP+QVLTtNujfnfiO4V9g5JrkOhB/Wm2Sr34VNFhQ==",
+			"dependencies": {
+				"@amplitude/analytics-client-common": "^2.0.9",
+				"@amplitude/analytics-types": "^2.3.1",
+				"tslib": "^2.4.1"
+			}
+		},
+		"node_modules/@amplitude/plugin-web-attribution-browser": {
+			"version": "2.0.16",
+			"resolved": "https://registry.npmjs.org/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.16.tgz",
+			"integrity": "sha512-IEYDrtZGJvBRhie7u9xIWNZhd0Z7heRx6A/+dNdERrW/akC1iAVmUyBZPMOR5ywVK7nwsymlVpFbPccuMoYTmg==",
+			"dependencies": {
+				"@amplitude/analytics-client-common": "^2.0.9",
+				"@amplitude/analytics-core": "^2.1.2",
+				"@amplitude/analytics-types": "^2.3.1",
+				"tslib": "^2.4.1"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -4390,8 +4455,7 @@
 		"node_modules/tslib": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-			"dev": true
+			"integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
 		},
 		"node_modules/type-detect": {
 			"version": "4.0.8",

--- a/panel-app/package-lock.json
+++ b/panel-app/package-lock.json
@@ -12,16 +12,16 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@ionic/core": "^7.5.6",
+				"@ionic/core": "^7.6.0",
 				"@stencil-community/router": "^1.0.2",
-				"@stencil/core": "4.7.2",
+				"@stencil/core": "4.8.1",
 				"@stencil/sass": "^3.0.7",
 				"@stencil/store": "^2.0.11",
 				"@types/chrome": "^0.0.253",
-				"@types/jest": "^29.5.10",
+				"@types/jest": "^29.5.11",
 				"jest": "^29.7.0",
 				"jest-cli": "^29.7.0",
-				"puppeteer": "^21.5.2",
+				"puppeteer": "^21.6.0",
 				"rollup-plugin-dotenv": "0.5.0"
 			}
 		},
@@ -39,12 +39,12 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.22.13",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-			"integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+			"integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.22.13",
+				"@babel/highlight": "^7.23.4",
 				"chalk": "^2.4.2"
 			},
 			"engines": {
@@ -123,30 +123,30 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.3.tgz",
-			"integrity": "sha512-BmR4bWbDIoFJmJ9z2cZ8Gmm2MXgEDgjdWgpKmKWUt54UGFJdlj31ECtbaDvCG/qVdG3AQ1SfpZEs01lUFbzLOQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.5.tgz",
+			"integrity": "sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
-			"integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
+			"integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.3",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.5",
 				"@babel/helper-compilation-targets": "^7.22.15",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.2",
-				"@babel/parser": "^7.23.3",
+				"@babel/helpers": "^7.23.5",
+				"@babel/parser": "^7.23.5",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.3",
-				"@babel/types": "^7.23.3",
+				"@babel/traverse": "^7.23.5",
+				"@babel/types": "^7.23.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -162,12 +162,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.3.tgz",
-			"integrity": "sha512-keeZWAV4LU3tW0qRi19HRpabC/ilM0HRBBzf9/k8FFiG4KVpiv0FIy4hHfLfFQZNhziCTPTmd59zoyv6DNISzg==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
+			"integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.23.3",
+				"@babel/types": "^7.23.5",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -291,9 +291,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-			"integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+			"integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -307,32 +307,32 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.22.15.tgz",
-			"integrity": "sha512-bMn7RmyFjY/mdECUbgn9eoSY4vqvacUnS9i9vGAGttgFWesO6B4CYWA7XlpbWgBt71iv/hfbPlynohStqnu5hA==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+			"integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
 			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
-			"integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
+			"integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.2",
-				"@babel/types": "^7.23.0"
+				"@babel/traverse": "^7.23.5",
+				"@babel/types": "^7.23.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-			"integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+			"version": "7.23.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+			"integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.22.20",
@@ -415,9 +415,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.3.tgz",
-			"integrity": "sha512-uVsWNvlVsIninV2prNz/3lHCb+5CJ+e+IUBfbjToAHODtfGYLfCFuY4AU7TskI+dAKk+njsPiBjq1gKTvZOBaw==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
+			"integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -618,19 +618,19 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.3.tgz",
-			"integrity": "sha512-+K0yF1/9yR0oHdE0StHuEj3uTPzwwbrLGfNOndVJVV2TqA5+j3oljJUb4nmB954FLGjNem976+B+eDuLIjesiQ==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
+			"integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.22.13",
-				"@babel/generator": "^7.23.3",
+				"@babel/code-frame": "^7.23.5",
+				"@babel/generator": "^7.23.5",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.3",
-				"@babel/types": "^7.23.3",
+				"@babel/parser": "^7.23.5",
+				"@babel/types": "^7.23.5",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
@@ -639,11 +639,11 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.3.tgz",
-			"integrity": "sha512-OZnvoH2l8PK5eUvEcUyCt/sXgr/h+UWpVuBbOljwcrAgUl6lpchoQ++PHGyQy1AtYnVA6CEq3y5xeEI10brpXw==",
+			"version": "7.23.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
+			"integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.22.5",
+				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
 				"to-fast-properties": "^2.0.0"
 			},
@@ -658,12 +658,12 @@
 			"dev": true
 		},
 		"node_modules/@ionic/core": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.5.6.tgz",
-			"integrity": "sha512-bYQp2twwm61uA0Q31ToVIpQWsiQ9so1dRoWZPD+l+y4fVuFmOCLYeS6XTLTm73jVBq40JfEcsac7eYC4DxoemQ==",
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.0.tgz",
+			"integrity": "sha512-pDX8G915puz8OcLhxfb9MwuvpYZsUOCngJdd+61ibJ6UF+NA2mGatsMqHKzcgelTXtwcHDpi9ZLUD/HNmupqaQ==",
 			"dev": true,
 			"dependencies": {
-				"@stencil/core": "^4.7.2",
+				"@stencil/core": "^4.8.1",
 				"ionicons": "^7.2.1",
 				"tslib": "^2.1.0"
 			}
@@ -1020,9 +1020,9 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.8.0.tgz",
-			"integrity": "sha512-TkRHIV6k2D8OlUe8RtG+5jgOF/H98Myx0M6AOafC8DdNVOFiBSFa5cpRDtpm8LXOa9sVwe0+e6Q3FC56X/DZfg==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.0.tgz",
+			"integrity": "sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==",
 			"dev": true,
 			"dependencies": {
 				"debug": "4.3.4",
@@ -1117,9 +1117,9 @@
 			}
 		},
 		"node_modules/@stencil/core": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.7.2.tgz",
-			"integrity": "sha512-sPPDYrXiTbfeUF5CCyfqysXK/yfTHC4xYR1+nHzGkS2vhRSBOLp0oPuB+xkJLKA+K2ZqDJUxpOnDxy1CLWwBXA==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.8.1.tgz",
+			"integrity": "sha512-KG1H10j24rlyxIqOI4CG8/h9T7ObTv7giW2H3u1qXV4KKrLykDOpMcLzpqNXqL2Fki3s1QvHyl/oaRvi5waWVw==",
 			"dev": true,
 			"bin": {
 				"stencil": "bin/stencil"
@@ -1169,9 +1169,9 @@
 			"dev": true
 		},
 		"node_modules/@types/babel__core": {
-			"version": "7.20.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.4.tgz",
-			"integrity": "sha512-mLnSC22IC4vcWiuObSRjrLd9XcBTGf59vUSoq2jkQDJ/QQ8PMI9rSuzE+aEV8karUMbskw07bKYoUJCKTUaygg==",
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+			"integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/parser": "^7.20.7",
@@ -1279,9 +1279,9 @@
 			}
 		},
 		"node_modules/@types/jest": {
-			"version": "29.5.10",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.10.tgz",
-			"integrity": "sha512-tE4yxKEphEyxj9s4inideLHktW/x6DwesIwWZ9NN1FKf9zbJYsnhBoA9vrHA/IuIOKwPa5PcFBNV4lpMIOEzyQ==",
+			"version": "29.5.11",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
+			"integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
 			"dev": true,
 			"dependencies": {
 				"expect": "^29.0.0",
@@ -1289,9 +1289,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.9.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.0.tgz",
-			"integrity": "sha512-nekiGu2NDb1BcVofVcEKMIwzlx4NjHlcjhoxxKBNLtz15Y1z7MYf549DFvkHSId02Ax6kGwWntIBPC3l/JZcmw==",
+			"version": "20.10.3",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
+			"integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -1304,9 +1304,9 @@
 			"dev": true
 		},
 		"node_modules/@types/yargs": {
-			"version": "17.0.31",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.31.tgz",
-			"integrity": "sha512-bocYSx4DI8TmdlvxqGpVNXOgCNR1Jj0gNPhhAY+iz1rgKDAaYrAYdFYnhDV1IFuiuVc9HkOwyDcFxaTElF3/wg==",
+			"version": "17.0.32",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
+			"integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
 			"dev": true,
 			"dependencies": {
 				"@types/yargs-parser": "*"
@@ -1584,9 +1584,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+			"integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
 			"dev": true,
 			"funding": [
 				{
@@ -1603,9 +1603,9 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001541",
-				"electron-to-chromium": "^1.4.535",
-				"node-releases": "^2.0.13",
+				"caniuse-lite": "^1.0.30001565",
+				"electron-to-chromium": "^1.4.601",
+				"node-releases": "^2.0.14",
 				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
@@ -1682,9 +1682,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001562",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001562.tgz",
-			"integrity": "sha512-kfte3Hym//51EdX4239i+Rmp20EsLIYGdPkERegTgU19hQWCRhsRFGKHTliUlsry53tv17K7n077Kqa0WJU4ng==",
+			"version": "1.0.30001566",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
+			"integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
 			"dev": true,
 			"funding": [
 				{
@@ -1727,9 +1727,9 @@
 			}
 		},
 		"node_modules/chromium-bidi": {
-			"version": "0.4.33",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.33.tgz",
-			"integrity": "sha512-IxoFM5WGQOIAd95qrSXzJUv4eXIrh+RvU3rwwqIiwYuvfE7U/Llj4fejbsJnjJMUYCuGtVQsY2gv7oGl4aTNSQ==",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.1.tgz",
+			"integrity": "sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==",
 			"dev": true,
 			"dependencies": {
 				"mitt": "3.0.1",
@@ -2008,9 +2008,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.584",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.584.tgz",
-			"integrity": "sha512-rXCtDiXCBtfTfEegkthruCvyWZnr1/FCrUGY/nYQiF+lSZDmwQBDxp0rivZxV8trXb6cbgojhcSTW5xsDcHQ8g==",
+			"version": "1.4.605",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.605.tgz",
+			"integrity": "sha512-V52j+P5z6cdRqTjPR/bYNxx7ETCHIkm5VIGuyCy3CMrfSnbEpIlLnk5oHmZo7gYvDfh2TfHeanB6rawyQ23ktg==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -3583,9 +3583,9 @@
 			"dev": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
 		},
 		"node_modules/normalize-path": {
@@ -3927,28 +3927,31 @@
 			}
 		},
 		"node_modules/puppeteer": {
-			"version": "21.5.2",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.5.2.tgz",
-			"integrity": "sha512-BaAGJOq8Fl6/cck6obmwaNLksuY0Bg/lIahCLhJPGXBFUD2mCffypa4A592MaWnDcye7eaHmSK9yot0pxctY8A==",
+			"version": "21.6.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.6.0.tgz",
+			"integrity": "sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@puppeteer/browsers": "1.8.0",
+				"@puppeteer/browsers": "1.9.0",
 				"cosmiconfig": "8.3.6",
-				"puppeteer-core": "21.5.2"
+				"puppeteer-core": "21.6.0"
+			},
+			"bin": {
+				"puppeteer": "lib/esm/puppeteer/node/cli.js"
 			},
 			"engines": {
 				"node": ">=16.13.2"
 			}
 		},
 		"node_modules/puppeteer-core": {
-			"version": "21.5.2",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.5.2.tgz",
-			"integrity": "sha512-v4T0cWnujSKs+iEfmb8ccd7u4/x8oblEyKqplqKnJ582Kw8PewYAWvkH4qUWhitN3O2q9RF7dzkvjyK5HbzjLA==",
+			"version": "21.6.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
+			"integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
 			"dev": true,
 			"dependencies": {
-				"@puppeteer/browsers": "1.8.0",
-				"chromium-bidi": "0.4.33",
+				"@puppeteer/browsers": "1.9.0",
+				"chromium-bidi": "0.5.1",
 				"cross-fetch": "4.0.0",
 				"debug": "4.3.4",
 				"devtools-protocol": "0.0.1203626",
@@ -4485,9 +4488,9 @@
 			}
 		},
 		"node_modules/v8-to-istanbul": {
-			"version": "9.1.3",
-			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.3.tgz",
-			"integrity": "sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+			"integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.12",

--- a/panel-app/package-lock.json
+++ b/panel-app/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "web-scraper-helper-panel",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "web-scraper-helper-panel",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"dependencies": {
 				"@types/babel__traverse": "^7.20.4",
 				"uuid": "^9.0.1"
@@ -21,7 +21,8 @@
 				"@types/jest": "^29.5.10",
 				"jest": "^29.7.0",
 				"jest-cli": "^29.7.0",
-				"puppeteer": "^21.5.2"
+				"puppeteer": "^21.5.2",
+				"rollup-plugin-dotenv": "0.5.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -1039,6 +1040,49 @@
 				"node": ">=16.3.0"
 			}
 		},
+		"node_modules/@rollup/plugin-replace": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-5.0.5.tgz",
+			"integrity": "sha512-rYO4fOi8lMaTg/z5Jb+hKnrHHVn8j2lwkqwyS4kTRhKyWOLf2wST2sWXr4WzWiTcoHTp2sTjqUbqIj2E39slKQ==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/pluginutils": "^5.0.1",
+				"magic-string": "^0.30.3"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@rollup/pluginutils": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.0.tgz",
+			"integrity": "sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==",
+			"dev": true,
+			"dependencies": {
+				"@types/estree": "^1.0.0",
+				"estree-walker": "^2.0.2",
+				"picomatch": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@sinclair/typebox": {
 			"version": "0.27.8",
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1173,6 +1217,12 @@
 				"@types/filesystem": "*",
 				"@types/har-format": "*"
 			}
+		},
+		"node_modules/@types/estree": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+			"integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+			"dev": true
 		},
 		"node_modules/@types/filesystem": {
 			"version": "0.0.35",
@@ -1945,6 +1995,18 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/dotenv": {
+			"version": "16.3.1",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+			"integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/motdotla/dotenv?sponsor=1"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.584",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.584.tgz",
@@ -2047,6 +2109,12 @@
 			"engines": {
 				"node": ">=4.0"
 			}
+		},
+		"node_modules/estree-walker": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+			"dev": true
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
@@ -3346,6 +3414,18 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/magic-string": {
+			"version": "0.30.5",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
+			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/sourcemap-codec": "^1.4.15"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -3960,6 +4040,39 @@
 			"dev": true,
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/rollup": {
+			"version": "3.29.4",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+			"integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+			"dev": true,
+			"peer": true,
+			"bin": {
+				"rollup": "dist/bin/rollup"
+			},
+			"engines": {
+				"node": ">=14.18.0",
+				"npm": ">=8.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.2"
+			}
+		},
+		"node_modules/rollup-plugin-dotenv": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-dotenv/-/rollup-plugin-dotenv-0.5.0.tgz",
+			"integrity": "sha512-M2gZqEZebtcKaA7OBdO4UF3WmkI02wVD6UVwoxFlRKoq4/n1Q9Cw6UV8dPvVZYpGQ+ug2JPoogrCLaydIKU96A==",
+			"dev": true,
+			"dependencies": {
+				"@rollup/plugin-replace": "^5.0.1",
+				"dotenv": "^16.0.3"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"rollup": "^1.20.0 || ^2.0.0 || ^3.0.0"
 			}
 		},
 		"node_modules/semver": {

--- a/panel-app/package.json
+++ b/panel-app/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "web-scraper-helper-panel",
 	"private": true,
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Stencil App for the Dev Tools panel of the Web Scraper Helper Chrome Extension",
 	"scripts": {
 		"build": "stencil build && rm -rf ../chrome_extension/www && cp -R www ../chrome_extension/www && cp index.html ../chrome_extension/www/index.html",
@@ -20,7 +20,8 @@
 		"@types/jest": "^29.5.10",
 		"jest": "^29.7.0",
 		"jest-cli": "^29.7.0",
-		"puppeteer": "^21.5.2"
+		"puppeteer": "^21.5.2",
+		"rollup-plugin-dotenv": "0.5.0"
 	},
 	"dependencies": {
 		"@types/babel__traverse": "^7.20.4",

--- a/panel-app/package.json
+++ b/panel-app/package.json
@@ -11,16 +11,16 @@
 		"generate": "stencil generate"
 	},
 	"devDependencies": {
-		"@ionic/core": "^7.5.6",
+		"@ionic/core": "^7.6.0",
 		"@stencil-community/router": "^1.0.2",
-		"@stencil/core": "4.7.2",
+		"@stencil/core": "4.8.1",
 		"@stencil/sass": "^3.0.7",
 		"@stencil/store": "^2.0.11",
 		"@types/chrome": "^0.0.253",
-		"@types/jest": "^29.5.10",
+		"@types/jest": "^29.5.11",
 		"jest": "^29.7.0",
 		"jest-cli": "^29.7.0",
-		"puppeteer": "^21.5.2",
+		"puppeteer": "^21.6.0",
 		"rollup-plugin-dotenv": "0.5.0"
 	},
 	"dependencies": {

--- a/panel-app/package.json
+++ b/panel-app/package.json
@@ -24,6 +24,7 @@
 		"rollup-plugin-dotenv": "0.5.0"
 	},
 	"dependencies": {
+		"@amplitude/analytics-browser": "^2.3.6",
 		"@types/babel__traverse": "^7.20.4",
 		"uuid": "^9.0.1"
 	},

--- a/panel-app/src/components/app-root/app-root.tsx
+++ b/panel-app/src/components/app-root/app-root.tsx
@@ -13,6 +13,12 @@ export class AppRoot {
 	@State() version: string = '';
 
 	componentDidLoad() {
+		let amplitudeKey = null;
+		try {
+			amplitudeKey = process.env.AMPLITUDE_KEY;
+		} catch (e) {}
+		console.log(amplitudeKey);
+
 		try {
 			let manifest = chrome.runtime.getManifest();
 			this.version = 'v' + manifest.version;

--- a/panel-app/stencil.config.ts
+++ b/panel-app/stencil.config.ts
@@ -1,5 +1,6 @@
 import { Config } from '@stencil/core';
 import { sass } from '@stencil/sass';
+import dotenvPlugin from 'rollup-plugin-dotenv';
 
 // https://stenciljs.com/docs/config
 
@@ -9,6 +10,7 @@ export const config: Config = {
 	taskQueue: 'async',
 	namespace: 'web-scraper-helper',
 	plugins: [
+		dotenvPlugin(),
 		sass({
 			includePaths: ['./node_modules'],
 		}),


### PR DESCRIPTION
Also: 
- bump version to `2.0.1`
- updated dependencies
- add dependency for Amplitude

Currently only showing the key in the console.
