### PR TITLE
Debug & Improvements on create new files

### DIFF
--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -60,3 +60,16 @@ chrome.runtime.onMessage.addListener(function (request, sender/*, sendResponse*/
   }
   return true;
 });
+
+// for "Error: Could not establish connection. Receiving end does not exist."
+// https://stackoverflow.com/questions/10994324/chrome-extension-content-script-re-injection-after-upgrade-or-install
+chrome.runtime.onInstalled.addListener(async () => {
+  for (const cs of chrome.runtime.getManifest().content_scripts) {
+    for (const tab of await chrome.tabs.query({ url: cs.matches })) {
+      chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        files: cs.js,
+      });
+    }
+  }
+});

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -30,6 +30,7 @@
     }
   ],
   "permissions": [
+    "scripting",
     "storage",
     "activeTab"
   ],

--- a/panel-app/package-lock.json
+++ b/panel-app/package-lock.json
@@ -18,7 +18,7 @@
 				"@stencil/core": "4.8.1",
 				"@stencil/sass": "^3.0.7",
 				"@stencil/store": "^2.0.11",
-				"@types/chrome": "^0.0.253",
+				"@types/chrome": "^0.0.254",
 				"@types/jest": "^29.5.11",
 				"jest": "^29.7.0",
 				"jest-cli": "^29.7.0",
@@ -1274,9 +1274,9 @@
 			}
 		},
 		"node_modules/@types/chrome": {
-			"version": "0.0.253",
-			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.253.tgz",
-			"integrity": "sha512-ZnBlbeoje0XaBrJbFCXI8DsDfqvqdoWQO5NSGecMCHFC8W8z/rb/n7lI1FHob+TFKKLR4L2c3QJJSFLwtVc9TA==",
+			"version": "0.0.254",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.254.tgz",
+			"integrity": "sha512-svkOGKwA+6ZZuk9xtrYun8MYpNY/9hD17rgZ19v3KunhsK1ZOKaMESw12/1AXLh1u3UPA8jQIRi2370DXv9wgw==",
 			"dev": true,
 			"dependencies": {
 				"@types/filesystem": "*",

--- a/panel-app/package.json
+++ b/panel-app/package.json
@@ -16,7 +16,7 @@
 		"@stencil/core": "4.8.1",
 		"@stencil/sass": "^3.0.7",
 		"@stencil/store": "^2.0.11",
-		"@types/chrome": "^0.0.253",
+		"@types/chrome": "^0.0.254",
 		"@types/jest": "^29.5.11",
 		"jest": "^29.7.0",
 		"jest-cli": "^29.7.0",

--- a/panel-app/src/components/app-root/app-root.tsx
+++ b/panel-app/src/components/app-root/app-root.tsx
@@ -13,11 +13,11 @@ export class AppRoot {
 	@State() version: string = '';
 
 	componentDidLoad() {
-		let amplitudeKey = null;
-		try {
-			amplitudeKey = process.env.AMPLITUDE_KEY;
-		} catch (e) {}
-		console.log(amplitudeKey);
+		// let amplitudeKey = null;
+		// try {
+		// 	amplitudeKey = process.env.AMPLITUDE_KEY;
+		// } catch (e) {}
+		// console.log(amplitudeKey);
 
 		try {
 			let manifest = chrome.runtime.getManifest();

--- a/panel-app/src/components/file-explorer/file-explorer.scss
+++ b/panel-app/src/components/file-explorer/file-explorer.scss
@@ -151,6 +151,7 @@
 				background-color: #fff;
 
 				&.create-new {
+					color: #00adff;
 					background-color: inherit;
 					border: 1px dashed var(--primary-gray-4, #d6dcdd);
 				}

--- a/panel-app/src/components/file-explorer/file-explorer.tsx
+++ b/panel-app/src/components/file-explorer/file-explorer.tsx
@@ -119,9 +119,7 @@ export class FileExplorer {
 	}
 
 	handleFileSelection(event) {
-		if (event?.target.value !== 'Sorry, you haven’t created any files yet.') {
-			this.loadFile(event.target.value);
-		}
+		this.loadFile(event.target.value);
 	}
 
 	loadFile(name) {

--- a/panel-app/src/components/file-explorer/file-explorer.tsx
+++ b/panel-app/src/components/file-explorer/file-explorer.tsx
@@ -31,6 +31,7 @@ export class FileExplorer {
 				name: this.newFileName,
 				triggerType: 'new-file',
 			};
+			state.hasChanges = false;
 		} catch (e) {
 			console.log(e);
 		}
@@ -67,6 +68,12 @@ export class FileExplorer {
 		return <ion-select-option class="no-files-option">Sorry, you haven’t created any files yet.</ion-select-option>;
 	}
 
+	private openModal() {
+		this.newFileName = '';
+		this.showModal = true;
+		setTimeout(() => (document.querySelector('#form-new-file-input-name input') as any)?.focus(), 250);
+	}
+
 	renderRecentFiles() {
 		if (this.recentFiles?.length) {
 			const recentFiles = this.recentFiles.map((item) => (
@@ -84,7 +91,7 @@ export class FileExplorer {
 					<div class="recent-subtitle">Choose one of recently created file or search for more in the list above.</div>
 					<div class="recent-files-section">
 						{recentFiles}
-						<div class="recent-file create-new" onClick={() => (this.showModal = true)}>
+						<div class="recent-file create-new" onClick={() => this.openModal()}>
 							<div class="recent-file-name">Create a new file</div>
 							<ion-icon name="add-circle-outline" size="small" color="primary"></ion-icon>
 						</div>
@@ -98,13 +105,7 @@ export class FileExplorer {
 				<div class="createFile-wrapper">
 					<div class="info-text">You have no files</div>
 					<div>
-						<ion-button
-							class="create-file-btn"
-							onClick={() => {
-								this.newFileName = '';
-								this.showModal = true;
-							}}
-						>
+						<ion-button class="create-file-btn" onClick={() => this.openModal()}>
 							<ion-icon slot="start" name="add-circle-outline"></ion-icon>
 							Create a new file
 						</ion-button>
@@ -186,18 +187,33 @@ export class FileExplorer {
 							<div>Create new file</div>
 							<ion-icon name="close-outline" onClick={() => (this.showModal = false)}></ion-icon>
 						</div>
-						<div class="modal-content">
-							<div>Enter a name for your Web Scraper file.</div>
-							<ion-input fill="outline" placeholder="Name" onIonInput={(event) => (this.newFileName = (event.target as HTMLIonInputElement).value as string)} value={this.newFileName}></ion-input>
-						</div>
-						<div class="modal-footer">
-							<ion-button fill="outline" onClick={() => (this.showModal = false)}>
-								Cancel
-							</ion-button>
-							<ion-button fill="outline" onClick={() => this.onSaveClick()} disabled={!this.newFileName}>
-								Save
-							</ion-button>
-						</div>
+						<form
+							onSubmit={(e) => {
+								e.preventDefault();
+								this.onSaveClick();
+								return true;
+							}}
+						>
+							<div class="modal-content">
+								<div>Enter a name for your Web Scraper file.</div>
+								<ion-input
+									id="form-new-file-input-name"
+									required={true}
+									fill="outline"
+									placeholder="Name"
+									onIonInput={(event) => (this.newFileName = (event.target as HTMLIonInputElement).value as string)}
+									value={this.newFileName}
+								></ion-input>
+							</div>
+							<div class="modal-footer">
+								<ion-button fill="outline" onClick={() => (this.showModal = false)}>
+									Cancel
+								</ion-button>
+								<ion-button fill="outline" onClick={() => this.onSaveClick()} disabled={!this.newFileName}>
+									Save
+								</ion-button>
+							</div>
+						</form>
 					</ion-modal>
 				</div>
 			</Host>

--- a/panel-app/src/components/store.ts
+++ b/panel-app/src/components/store.ts
@@ -292,7 +292,8 @@ const addToRecentFiles = async (filename: string): Promise<string[]> => {
 const sendMessageToContentScript = (message: any, callback: any = null): any => {
 	try {
 		chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-			chrome.tabs.sendMessage(tabs[0].id, message, null, callback);
+			console.log('tabs', tabs);
+			if (tabs?.length && tabs[0].id) chrome.tabs.sendMessage(tabs[0].id, message, null, callback);
 		});
 	} catch (e) {
 		console.log(e);

--- a/panel-app/src/global/app.scss
+++ b/panel-app/src/global/app.scss
@@ -15,6 +15,7 @@ body {
 }
 
 ion-popover .no-files-option {
+	pointer-events: none;
 	color: #565b66;
 	font-family: Gibson;
 	font-size: 14px;
@@ -157,9 +158,9 @@ ion-toast {
 	--max-width: 310px;
 	--offset-y: -5px;
 
-	& ion-content{
+	& ion-content {
 		--border-radius: 8px 8px 0px 0px;
-		--background: #3F3F71;
+		--background: #3f3f71;
 		--color: #fff;
 		font-family: Gibson;
 		font-size: 14px;


### PR DESCRIPTION
A few fixes: 
- An attempt to fix "Error: Could not establish connection. Receiving end does not exist."m with `chrome.runtime.onInstalled.addListener`
- Set focus on input on opening the New file modal
- Support "enter" on the input box to submit in the New file modal
- Remove dirty flag after creating a file
- Change color of "create new file" action in the Recent file list, people were not seeing it
- Remove the check for "Sorry", I changed the CSS style to prevent clicks on it through `pointer-events`
- Set a trace for `tabs` for debugging, will remove in next version.