### PR TITLE
LAB-762 apply styles on navigation

### DIFF
--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -25,3 +25,18 @@ chrome.runtime.onInstalled.addListener(async () => {
   }
 });
 
+let devtoolsOpened = false;
+
+chrome.runtime.onConnect.addListener(port => {
+  port.onMessage.addListener(message => {
+    if (message.type === 'devtools-opened') {
+      devtoolsOpened = true;
+    }
+  });
+});
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message.type === 'page-loaded' && devtoolsOpened) {
+    chrome.tabs.sendMessage(sender.tab.id, { type: 'page-loaded' });
+  }
+});

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -369,3 +369,10 @@ function removePreviouslyExcludedStyles() {
   }
 }
 
+window.onload = () => {
+  chrome.runtime.sendMessage({
+    type: 'page-loaded',
+  }, (res) => {
+    console.log('RES:', res);
+  });
+};

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -372,7 +372,5 @@ function removePreviouslyExcludedStyles() {
 window.onload = () => {
   chrome.runtime.sendMessage({
     type: 'page-loaded',
-  }, (res) => {
-    console.log('RES:', res);
   });
 };

--- a/chrome_extension/devtools.js
+++ b/chrome_extension/devtools.js
@@ -5,3 +5,6 @@ chrome.devtools.panels.create(
   "icons/16.png",
   "www/index.html"
 );
+
+const port = chrome.runtime.connect({ name: "devtools" });
+port.postMessage({ type: "devtools-opened" });

--- a/panel-app/src/components/create-config/create-config.tsx
+++ b/panel-app/src/components/create-config/create-config.tsx
@@ -93,7 +93,7 @@ export class CreateConfig {
 		updateGlobalName(e.detail.value);
 	}
 
-	async componentWillLoad() {
+	async loadFile() {
 		try {
 			if (state.currentFile?.triggerType === 'load-file') {
 				const fileName = state.currentFile.name;
@@ -110,6 +110,19 @@ export class CreateConfig {
 		} catch (e) {
 			console.log(e);
 		}
+	}
+
+	addPageLoadListener() {
+		chrome.runtime.onMessage.addListener((message) => {
+			if (message.type === 'page-loaded') {
+				this.loadFile();
+			}
+		});
+	}
+
+	async componentWillLoad() {
+		this.loadFile();
+		this.addPageLoadListener();
 	}
 
 	componentDidLoad() {


### PR DESCRIPTION
Added logic to support the re-application of exclude styles on new page load/navigation. 
Also re-extracts metadata for the same