### PR TITLE
LAB-762 Inject content-script dynamically

### DIFF
--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -3,40 +3,7 @@
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
   // Messages from content scripts should have sender.tab set
   if (sender?.tab) {
-    sendResponse(request);
+    sendResponse({ tabId: sender.tab.id, ...request });
     return true;
-  }
-});
-
-// for "Error: Could not establish connection. Receiving end does not exist."
-// https://stackoverflow.com/questions/10994324/chrome-extension-content-script-re-injection-after-upgrade-or-install
-chrome.runtime.onInstalled.addListener(async () => {
-  try {
-    for (const cs of chrome.runtime.getManifest().content_scripts) {
-      for (const tab of await chrome.tabs.query({ url: cs.matches })) {
-        chrome.scripting.executeScript({
-          target: { tabId: tab.id },
-          files: cs.js,
-        });
-      }
-    }
-  } catch (e) {
-    console.error('onInstalled.addListener', e);
-  }
-});
-
-let devtoolsOpened = false;
-
-chrome.runtime.onConnect.addListener(port => {
-  port.onMessage.addListener(message => {
-    if (message.type === 'devtools-opened') {
-      devtoolsOpened = true;
-    }
-  });
-});
-
-chrome.runtime.onMessage.addListener((message, sender) => {
-  if (message.type === 'page-loaded' && devtoolsOpened) {
-    chrome.tabs.sendMessage(sender.tab.id, { type: 'page-loaded' });
   }
 });

--- a/chrome_extension/background.js
+++ b/chrome_extension/background.js
@@ -25,3 +25,18 @@ chrome.runtime.onInstalled.addListener(async () => {
   }
 });
 
+let devtoolsOpened = false;
+
+chrome.runtime.onConnect.addListener(port => {
+  port.onMessage.addListener(message => {
+    if (message.type === 'devtools-opened') {
+      devtoolsOpened = true;
+    }
+  });
+});
+
+chrome.runtime.onMessage.addListener((message, sender) => {
+  if (message.type === 'page-loaded' && devtoolsOpened) {
+    chrome.tabs.sendMessage(sender.tab.id, { type: 'page-loaded' });
+  }
+});

--- a/chrome_extension/content-reload.js
+++ b/chrome_extension/content-reload.js
@@ -1,0 +1,23 @@
+if (typeof __wsh_reload === 'undefined') {
+  function __wsh_reload() {
+    chrome.runtime.sendMessage({ type: 'page-loaded' }, (response) => {
+      if (!window.__WSH_tabid && response?.tabId) {
+        window.__WSH_tabid = response.tabId;
+      }
+    });
+  }
+
+  // window.addEventListener('hashchange', __wsh_reload);
+  // window.addEventListener('popstate', __wsh_reload);
+
+  let __wsh_lastUrl = location.href;
+  new MutationObserver(() => {
+    const url = location.href;
+    if (url !== __wsh_lastUrl) {
+      __wsh_lastUrl = url;
+      setTimeout(__wsh_reload, 500);
+    }
+  }).observe(document, { subtree: true, childList: true });
+}
+
+__wsh_reload();

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -252,7 +252,7 @@ if (!window.__WSH_content_script_loaded) {
 
   chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (!(window.__WSH_tabid && window.__WSH_tabid === message.tabId)) {
-      // console.log('not mine, ignoring', window.__WSH_tabid, '!==', message.tabId);
+      // console.log('Message is not for this tab, ignoring.', window.__WSH_tabid, '!==', message.tabId);
       return;
     }
     // console.log('onMessage', window.__WSH_tabid, message);
@@ -278,7 +278,7 @@ if (!window.__WSH_content_script_loaded) {
       } catch (e) {
         response = 'Invalid';
       }
-      // console.log('validate-selector', message, response);
+
       sendResponse(response);
     }
     if (message.type === 'update-excludeItem-onLoad') {
@@ -379,6 +379,3 @@ if (!window.__WSH_content_script_loaded) {
   }
 
 }
-// // else {
-// //   console.log('content-script already loaded');
-// }

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -369,3 +369,10 @@ function removePreviouslyExcludedStyles() {
   }
 }
 
+window.onload = () => {
+  chrome.runtime.sendMessage({
+    type: 'page-loaded',
+  }, (res) => {
+    console.log('RES:', res);
+  });
+};

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -372,7 +372,5 @@ function removePreviouslyExcludedStyles() {
 window.onload = () => {
   chrome.runtime.sendMessage({
     type: 'page-loaded',
-  }, (res) => {
-    console.log('RES:', res);
   });
 };

--- a/chrome_extension/content-script.js
+++ b/chrome_extension/content-script.js
@@ -2,375 +2,383 @@
 // jshint -W110, -W003
 /*global chrome*/
 
-class RulePath {
-  constructor(spec, title, subItemName, container) {
-    this.path = spec.path;
-    this.isBoolean = spec.isBoolean ? true : false;
-    if (title) {
-      this.title = title;
-    } else if (spec.name) {
-      this.title = spec.name;
-    }
-    this.id = spec.id;
+if (!window.__WSH_content_script_loaded) {
+  window.__WSH_content_script_loaded = true;
 
-    this.container = container || null;
-
-    if (subItemName) {
-      this.subItemName = subItemName;
-    }
-    return this;
-  }
-
-  getElements() {
-    return null;
-  }
-
-  exludeFromPage() {
-    let elements = this.getElements(true);
-    (elements || []).forEach(e => {
-      if (e && e.classList) {
-        e.classList.add('web-scraper-helper-exclude');
+  class RulePath {
+    constructor(spec, title, subItemName, container) {
+      this.path = spec.path;
+      this.isBoolean = spec.isBoolean ? true : false;
+      if (title) {
+        this.title = title;
+      } else if (spec.name) {
+        this.title = spec.name;
       }
-    });
-  }
+      this.id = spec.id;
 
-  formatError(err) {
-    return `[${this.title}] Failed to parse ${this.type} "${this.path}"\n${err}`;
-  }
+      this.container = container || null;
 
-  toJson() {
-    let o = {
-      type: this.type,
-      path: this.path
-    };
-    if (this.subItemName) {
-      o.subItemName = this.subItemName;
-    }
-    if (this.isBoolean) {
-      o.isBoolean = true;
-    }
-    if (this.title !== undefined) {
-      o.title = this.title;
-    }
-    let elements = this.getElements();
-    if (elements) {
-      o.value = elements;
-    }
-    if (this._error) {
-      o.error = this.error;
-    }
-    return o;
-  }
-
-  toString() {
-    return JSON.stringify(this.toJson());
-  }
-
-  isError() {
-    return this._error ? true : false;
-  }
-
-  /**
-   * isValid means some element in the page matches this rule.
-   */
-  isValid() {
-    if (this._isValid === undefined) {
-      this._elements = this.getElements();
-      this._isValid = this._elements && this._elements.length ? true : false;
-    }
-    return this._isValid;
-  }
-}
-
-class CssRule extends RulePath {
-  constructor(spec, title, subItemKey, container) {
-    super(spec, title, subItemKey, container);
-    this.type = 'CSS';
-    this.isValid();
-  }
-
-  getTextNodes(container) {
-    let aNodes = [];
-    (container.childNodes || []).forEach(c => {
-      if (c.nodeType === 3) {
-        aNodes.push(c);
+      if (subItemName) {
+        this.subItemName = subItemName;
       }
-    });
-    return aNodes;
-  }
+      return this;
+    }
 
-  getElements(asIs = false) {
-    try {
-      let reTextSub = /::text\b/;
-      let reAttrSub = /::attr\b/;
-      let shouldReturnAttr = false;
-      let attrToGet = '';
-      let shouldReturnText = false;
-
-      let cssSelector = this.path || '';
-      if (reTextSub.test(cssSelector)) {
-        shouldReturnText = true;
-        cssSelector = cssSelector.split(reTextSub)[0];
-      }
-
-      if (reAttrSub.test(cssSelector)) {
-        shouldReturnAttr = true;
-        attrToGet = cssSelector.split(reAttrSub)[1].slice(1, -1);
-        cssSelector = cssSelector.split(reAttrSub)[0];
-      }
-
-      let container = this.container || document;
-      let nodes = [],
-        elements = [];
-
-      let n = container.querySelectorAll(cssSelector);
-      n.forEach(e => {
-        nodes.push(e);
-      });
-
-      if (this.isBoolean) {
-        return [nodes && nodes.length ? true : false];
-      }
-
-      (nodes || []).forEach(e => {
-        let value = e;
-        if (shouldReturnText) {
-          value = this.getTextNodes(e)
-            .map(n => (n.textContent || '').trim())
-            .filter(t => t)
-            .join('\n');
-        }
-
-        if (shouldReturnAttr) {
-          value = e.getAttribute(attrToGet);
-        }
-
-        if (!asIs && (typeof value === "object") && value.outerHTML) {
-          value = value.outerHTML;
-        }
-
-        elements.push(value);
-      });
-      return elements;
-    } catch (err) {
-      // console.error(err);
-      this._error = this.formatError(err);
+    getElements() {
       return null;
     }
-  }
-}
 
-class XPathRule extends RulePath {
-  constructor(spec, title, subItemKey, container) {
-    super(spec, title, subItemKey, container);
-    this.type = 'XPATH';
-    this.isValid();
-  }
+    exludeFromPage() {
+      let elements = this.getElements(true);
+      (elements || []).forEach(e => {
+        if (e && e.classList) {
+          e.classList.add('web-scraper-helper-exclude');
+        }
+      });
+    }
 
-  /**
-   *
-   * @param {*} asIs if true, return the element as is, not as text.
-   */
-  getElements(asIs) {
-    try {
-      let path = this.path;
-      if (this.container && path && path.startsWith('//')) {
-        path = '.' + this.path;
+    formatError(err) {
+      return `[${this.title}] Failed to parse ${this.type} "${this.path}"\n${err}`;
+    }
+
+    toJson() {
+      let o = {
+        type: this.type,
+        path: this.path
+      };
+      if (this.subItemName) {
+        o.subItemName = this.subItemName;
       }
-      let nodes = document.evaluate(path, this.container || document);
-      let e,
-        elements = [];
+      if (this.isBoolean) {
+        o.isBoolean = true;
+      }
+      if (this.title !== undefined) {
+        o.title = this.title;
+      }
+      let elements = this.getElements();
+      if (elements) {
+        o.value = elements;
+      }
+      if (this._error) {
+        o.error = this.error;
+      }
+      return o;
+    }
 
-      switch (nodes.resultType) {
-        case XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
-        case XPathResult.ORDERED_NODE_ITERATOR_TYPE:
-          while ((e = nodes.iterateNext())) {
-            let value = e.nodeValue;
-            if (asIs) {
-              value = e;
-            } else if (value === null) {
-              value = e.outerHTML;
-            }
-            elements.push(value);
+    toString() {
+      return JSON.stringify(this.toJson());
+    }
+
+    isError() {
+      return this._error ? true : false;
+    }
+
+    /**
+     * isValid means some element in the page matches this rule.
+     */
+    isValid() {
+      if (this._isValid === undefined) {
+        this._elements = this.getElements();
+        this._isValid = this._elements && this._elements.length ? true : false;
+      }
+      return this._isValid;
+    }
+  }
+
+  class CssRule extends RulePath {
+    constructor(spec, title, subItemKey, container) {
+      super(spec, title, subItemKey, container);
+      this.type = 'CSS';
+      this.isValid();
+    }
+
+    getTextNodes(container) {
+      let aNodes = [];
+      (container.childNodes || []).forEach(c => {
+        if (c.nodeType === 3) {
+          aNodes.push(c);
+        }
+      });
+      return aNodes;
+    }
+
+    getElements(asIs = false) {
+      try {
+        let reTextSub = /::text\b/;
+        let reAttrSub = /::attr\b/;
+        let shouldReturnAttr = false;
+        let attrToGet = '';
+        let shouldReturnText = false;
+
+        let cssSelector = this.path || '';
+        if (reTextSub.test(cssSelector)) {
+          shouldReturnText = true;
+          cssSelector = cssSelector.split(reTextSub)[0];
+        }
+
+        if (reAttrSub.test(cssSelector)) {
+          shouldReturnAttr = true;
+          attrToGet = cssSelector.split(reAttrSub)[1].slice(1, -1);
+          cssSelector = cssSelector.split(reAttrSub)[0];
+        }
+
+        let container = this.container || document;
+        let nodes = [],
+          elements = [];
+
+        let n = container.querySelectorAll(cssSelector);
+        n.forEach(e => {
+          nodes.push(e);
+        });
+
+        if (this.isBoolean) {
+          return [nodes && nodes.length ? true : false];
+        }
+
+        (nodes || []).forEach(e => {
+          let value = e;
+          if (shouldReturnText) {
+            value = this.getTextNodes(e)
+              .map(n => (n.textContent || '').trim())
+              .filter(t => t)
+              .join('\n');
           }
-          break;
-        case XPathResult.NUMBER_TYPE:
-          elements.push(nodes.numberValue);
-          break;
-        case XPathResult.STRING_TYPE:
-          elements.push(nodes.stringValue);
-          break;
-        case XPathResult.BOOLEAN_TYPE:
-          elements.push(nodes.booleanValue);
-          break;
-      }
 
-      if (this.isBoolean) {
-        return [elements && elements.length ? true : false];
-      }
+          if (shouldReturnAttr) {
+            value = e.getAttribute(attrToGet);
+          }
 
-      return elements;
-    } catch (err) {
-      // console.error(err);
-      this._error = this.formatError(err);
-      return null;
+          if (!asIs && (typeof value === "object") && value.outerHTML) {
+            value = value.outerHTML;
+          }
+
+          elements.push(value);
+        });
+        return elements;
+      } catch (err) {
+        // console.error(err);
+        this._error = this.formatError(err);
+        return null;
+      }
     }
   }
-}
 
-class ErrorRule extends RulePath {
-  constructor(spec, title) {
-    super(spec, title);
-    this.type = 'ERROR';
-    this._error = 'Unknown type: ' + JSON.stringify(spec);
-  }
-}
+  class XPathRule extends RulePath {
+    constructor(spec, title, subItemKey, container) {
+      super(spec, title, subItemKey, container);
+      this.type = 'XPATH';
+      this.isValid();
+    }
 
-let createRule = (obj, title, subItemKey, container) => {
-  if (obj.type === 'CSS') {
-    return new CssRule(obj, title, subItemKey, container);
-  }
-  if (obj.type === 'XPATH') {
-    return new XPathRule(obj, title, subItemKey, container);
-  }
-  return new ErrorRule(obj, title);
-};
+    /**
+     *
+     * @param {*} asIs if true, return the element as is, not as text.
+     */
+    getElements(asIs) {
+      try {
+        let path = this.path;
+        if (this.container && path && path.startsWith('//')) {
+          path = '.' + this.path;
+        }
+        let nodes = document.evaluate(path, this.container || document);
+        let e,
+          elements = [];
 
-let getParentsElements = (parentSelector) => {
-  let parents = null;
-  if (parentSelector) {
-    parents = createRule(parentSelector).getElements(true);
-  }
-  if (!parents) {
-    parents = [document];
-  }
-  return parents;
-};
+        switch (nodes.resultType) {
+          case XPathResult.UNORDERED_NODE_ITERATOR_TYPE:
+          case XPathResult.ORDERED_NODE_ITERATOR_TYPE:
+            while ((e = nodes.iterateNext())) {
+              let value = e.nodeValue;
+              if (asIs) {
+                value = e;
+              } else if (value === null) {
+                value = e.outerHTML;
+              }
+              elements.push(value);
+            }
+            break;
+          case XPathResult.NUMBER_TYPE:
+            elements.push(nodes.numberValue);
+            break;
+          case XPathResult.STRING_TYPE:
+            elements.push(nodes.stringValue);
+            break;
+          case XPathResult.BOOLEAN_TYPE:
+            elements.push(nodes.booleanValue);
+            break;
+        }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.type === 'exclude-selector') {
-    const { newItem, oldItem, parentSelector } = message.payload;
-    applyStylesToElements(newItem, oldItem, parentSelector);
-  }
-  if (message.type === 'validate-selector') {
-    let response = 'Invalid';
-    const { type, selector } = message.payload;
+        if (this.isBoolean) {
+          return [elements && elements.length ? true : false];
+        }
 
-    try {
-      const elements = createRule(message.payload).getElements(true);
-      if (elements === null) {
+        return elements;
+      } catch (err) {
+        // console.error(err);
+        this._error = this.formatError(err);
+        return null;
+      }
+    }
+  }
+
+  class ErrorRule extends RulePath {
+    constructor(spec, title) {
+      super(spec, title);
+      this.type = 'ERROR';
+      this._error = 'Unknown type: ' + JSON.stringify(spec);
+    }
+  }
+
+  let createRule = (obj, title, subItemKey, container) => {
+    if (obj.type === 'CSS') {
+      return new CssRule(obj, title, subItemKey, container);
+    }
+    if (obj.type === 'XPATH') {
+      return new XPathRule(obj, title, subItemKey, container);
+    }
+    return new ErrorRule(obj, title);
+  };
+
+  let getParentsElements = (parentSelector) => {
+    let parents = null;
+    if (parentSelector) {
+      parents = createRule(parentSelector).getElements(true);
+    }
+    if (!parents) {
+      parents = [document];
+    }
+    return parents;
+  };
+
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (!(window.__WSH_tabid && window.__WSH_tabid === message.tabId)) {
+      // console.log('not mine, ignoring', window.__WSH_tabid, '!==', message.tabId);
+      return;
+    }
+    // console.log('onMessage', window.__WSH_tabid, message);
+
+    if (message.type === 'exclude-selector') {
+      const { newItem, oldItem, parentSelector } = message.payload;
+      applyStylesToElements(newItem, oldItem, parentSelector);
+    }
+    if (message.type === 'validate-selector') {
+      let response = 'Invalid';
+      const { type, selector } = message.payload;
+
+      try {
+        const elements = createRule(message.payload).getElements(true);
+        if (elements === null) {
+          response = 'Invalid';
+        }
+        else if (elements?.length > 0) {
+          response = 'Valid';
+        } else {
+          response = 'No element found';
+        }
+      } catch (e) {
         response = 'Invalid';
       }
-      else if (elements?.length > 0) {
-        response = 'Valid';
-      } else {
-        response = 'No element found';
-      }
-    } catch (e) {
-      response = 'Invalid';
+      // console.log('validate-selector', message, response);
+      sendResponse(response);
     }
-    // console.log('validate-selector', message, response);
-    sendResponse(response);
-  }
-  if (message.type === 'update-excludeItem-onLoad') {
-    const { exclude, subItems } = message.payload;
-    exclude.length && exclude.map((element) => applyStylesToElements(element));
-    subItems.map(subItem => {
-      subItem.exclude.length && subItem.exclude.map((element) => applyStylesToElements(element, null, { type: subItem.type, path: subItem.path }));
-    });
-  }
-  if (message.type === 'remove-exclude-selector') {
-    const { item, parentSelector } = message.payload;
-    try {
+    if (message.type === 'update-excludeItem-onLoad') {
+      const { exclude, subItems } = message.payload;
+      exclude.length && exclude.map((element) => applyStylesToElements(element));
+      subItems.map(subItem => {
+        subItem.exclude.length && subItem.exclude.map((element) => applyStylesToElements(element, null, { type: subItem.type, path: subItem.path }));
+      });
+    }
+    if (message.type === 'remove-exclude-selector') {
+      const { item, parentSelector } = message.payload;
+      try {
+        let parents = getParentsElements(parentSelector);
+        parents.forEach(parent => {
+          const elements = createRule(item, null, null, parent).getElements(true);
+          elements?.forEach(element => {
+            element.classList?.remove('web-scraper-helper-exclude');
+          });
+        });
+      } catch (e) {
+        console.log(e);
+      }
+    }
+    if (message.type === 'remove-excluded-on-file-close') {
+      removePreviouslyExcludedStyles();
+    }
+    if (message.type === 'metadata-results') {
+      const { metadata, parentSelector } = message.payload;
+      const results = [];
       let parents = getParentsElements(parentSelector);
       parents.forEach(parent => {
-        const elements = createRule(item, null, null, parent).getElements(true);
-        elements?.forEach(element => {
-          element.classList?.remove('web-scraper-helper-exclude');
+        const result = [];
+        for (const [, value] of Object.entries(metadata)) {
+          const { name } = value;
+          const rule = createRule(value, null, null, parent);
+          result.push({ "name": name, "values": rule.getElements() });
+        }
+        results.push(result);
+      });
+      console.log('metadata-result-array', message, results);
+      sendResponse(results);
+    }
+    if (message.type === 'update-parentSelector-style') {
+      const { newSelector, oldSelector } = message.payload;
+      if (oldSelector && oldSelector.path !== newSelector.path) {
+        const oldElements = createRule(oldSelector).getElements(true);
+        oldElements?.forEach(element => {
+          element.classList.remove('web-scraper-subItem-parentSelector');
         });
+      }
+
+      const newElements = createRule(newSelector).getElements(true);
+      newElements?.forEach(element => {
+        element.classList.add('web-scraper-subItem-parentSelector');
+      });
+    }
+    if (message.type === 'remove-parentSelector-style') {
+      document.querySelectorAll('.web-scraper-subItem-parentSelector').forEach(element => {
+        element.classList.remove('web-scraper-subItem-parentSelector');
+      });
+    }
+  });
+
+  function applyStylesToElements(newItem, oldItem = null, parentSelector = null) {
+    try {
+      let parents = getParentsElements(parentSelector);
+      if (oldItem && oldItem.path !== newItem.path) {
+        parents.forEach(parent => {
+          const oldElements = createRule(oldItem, null, null, parent).getElements(true);
+          oldElements?.forEach(element => {
+            element.classList.remove('web-scraper-helper-exclude');
+          });
+        });
+      }
+
+      parents.forEach(parent => {
+        let newElements = createRule(newItem, null, null, parent).getElements(true);;
+        newElements?.forEach(element => {
+          element?.classList?.add('web-scraper-helper-exclude');
+        });
+      });
+
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  function removePreviouslyExcludedStyles() {
+    try {
+      document.querySelectorAll('.web-scraper-helper-exclude, .web-scraper-subItem-parentSelector').forEach(e => {
+        if (e && e.classList) {
+          e.classList.remove('web-scraper-helper-exclude', 'web-scraper-subItem-parentSelector');
+        }
       });
     } catch (e) {
       console.log(e);
     }
   }
-  if (message.type === 'remove-excluded-on-file-close') {
-    removePreviouslyExcludedStyles();
-  }
-  if (message.type === 'metadata-results') {
-    const { metadata, parentSelector } = message.payload;
-    const results = [];
-    let parents = getParentsElements(parentSelector);
-    parents.forEach(parent => {
-      const result = [];
-      for (const [, value] of Object.entries(metadata)) {
-        const { name } = value;
-        const rule = createRule(value, null, null, parent);
-        result.push({ "name": name, "values": rule.getElements() });
-      }
-      results.push(result);
-    });
-    console.log('metadata-result-array', message, results);
-    sendResponse(results);
-  }
-  if (message.type === 'update-parentSelector-style') {
-    const { newSelector, oldSelector } = message.payload;
-    if (oldSelector && oldSelector.path !== newSelector.path) {
-      const oldElements = createRule(oldSelector).getElements(true);
-      oldElements?.forEach(element => {
-        element.classList.remove('web-scraper-subItem-parentSelector');
-      });
-    }
 
-    const newElements = createRule(newSelector).getElements(true);
-    newElements?.forEach(element => {
-      element.classList.add('web-scraper-subItem-parentSelector');
-    });
-  }
-  if (message.type === 'remove-parentSelector-style') {
-    document.querySelectorAll('.web-scraper-subItem-parentSelector').forEach(element => {
-      element.classList.remove('web-scraper-subItem-parentSelector');
-    });
-  }
-});
-
-function applyStylesToElements(newItem, oldItem = null, parentSelector = null) {
-  try {
-    let parents = getParentsElements(parentSelector);
-    if (oldItem && oldItem.path !== newItem.path) {
-      parents.forEach(parent => {
-        const oldElements = createRule(oldItem, null, null, parent).getElements(true);
-        oldElements?.forEach(element => {
-          element.classList.remove('web-scraper-helper-exclude');
-        });
-      });
-    }
-
-    parents.forEach(parent => {
-      let newElements = createRule(newItem, null, null, parent).getElements(true);;
-      newElements?.forEach(element => {
-        element?.classList?.add('web-scraper-helper-exclude');
-      });
-    });
-
-  } catch (error) {
-    console.log(error);
-  }
 }
-
-function removePreviouslyExcludedStyles() {
-  try {
-    document.querySelectorAll('.web-scraper-helper-exclude, .web-scraper-subItem-parentSelector').forEach(e => {
-      if (e && e.classList) {
-        e.classList.remove('web-scraper-helper-exclude', 'web-scraper-subItem-parentSelector');
-      }
-    });
-  } catch (e) {
-    console.log(e);
-  }
-}
-
-window.onload = () => {
-  chrome.runtime.sendMessage({
-    type: 'page-loaded',
-  });
-};
+// // else {
+// //   console.log('content-script already loaded');
+// }

--- a/chrome_extension/devtools.js
+++ b/chrome_extension/devtools.js
@@ -5,3 +5,6 @@ chrome.devtools.panels.create(
   "icons/16.png",
   "www/index.html"
 );
+
+const port = chrome.runtime.connect({ name: "devtools" });
+port.postMessage({ type: "devtools-opened" });

--- a/chrome_extension/devtools.js
+++ b/chrome_extension/devtools.js
@@ -6,5 +6,5 @@ chrome.devtools.panels.create(
   "www/index.html"
 );
 
-const port = chrome.runtime.connect({ name: "devtools" });
+const port = chrome.runtime.connect({ name: "web-scraper-helper-v2" });
 port.postMessage({ type: "devtools-opened" });

--- a/chrome_extension/manifest.json
+++ b/chrome_extension/manifest.json
@@ -16,12 +16,25 @@
 	"content_scripts": [
 		{
 			"run_at": "document_end",
-			"matches": ["http://*/*", "https://*/*"],
-			"js": ["content-script.js"],
-			"css": ["css/inject.css"],
+			"matches": [
+				"http://*/*",
+				"https://*/*"
+			],
+			"js": [
+				"content-reload.js"
+			],
+			"css": [
+				"css/inject.css"
+			],
 			"all_frames": false
 		}
 	],
-	"permissions": ["scripting", "storage", "activeTab"],
-	"host_permissions": ["<all_urls>"]
+	"permissions": [
+		"scripting",
+		"storage",
+		"activeTab"
+	],
+	"host_permissions": [
+		"<all_urls>"
+	]
 }

--- a/panel-app/package-lock.json
+++ b/panel-app/package-lock.json
@@ -13,7 +13,7 @@
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@ionic/core": "^7.6.3",
+				"@ionic/core": "^7.6.4",
 				"@stencil-community/router": "^1.0.2",
 				"@stencil/core": "4.9.1",
 				"@stencil/sass": "^3.0.8",
@@ -723,12 +723,12 @@
 			"dev": true
 		},
 		"node_modules/@ionic/core": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.3.tgz",
-			"integrity": "sha512-KT8RXcbLRoCvj2wQNZJ0FAM+PlcVZZT0N3BPYPAiyTLA/rmMnlPGxNMMqGEJMynL8oPx/2nh+bLS2Yv/kBPnug==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.4.tgz",
+			"integrity": "sha512-9BGksEmvA/upb5Oup+joOam7y4pSBGCxYekWnTx8PiYur04ZYjGSZ0Vz3dQRyqj7rF+MwUV9iUGd3qz/bslkSw==",
 			"dev": true,
 			"dependencies": {
-				"@stencil/core": "^4.8.2",
+				"@stencil/core": "^4.9.1",
 				"ionicons": "^7.2.2",
 				"tslib": "^2.1.0"
 			}

--- a/panel-app/package-lock.json
+++ b/panel-app/package-lock.json
@@ -1,51 +1,51 @@
 {
 	"name": "web-scraper-helper-panel",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "web-scraper-helper-panel",
-			"version": "2.0.1",
+			"version": "2.0.2",
 			"dependencies": {
-				"@amplitude/analytics-browser": "^2.3.6",
-				"@types/babel__traverse": "^7.20.4",
+				"@amplitude/analytics-browser": "^2.3.8",
+				"@types/babel__traverse": "^7.20.5",
 				"uuid": "^9.0.1"
 			},
 			"devDependencies": {
-				"@ionic/core": "^7.6.0",
+				"@ionic/core": "^7.6.3",
 				"@stencil-community/router": "^1.0.2",
-				"@stencil/core": "4.8.1",
-				"@stencil/sass": "^3.0.7",
-				"@stencil/store": "^2.0.11",
-				"@types/chrome": "^0.0.254",
+				"@stencil/core": "4.9.1",
+				"@stencil/sass": "^3.0.8",
+				"@stencil/store": "^2.0.12",
+				"@types/chrome": "^0.0.256",
 				"@types/jest": "^29.5.11",
 				"jest": "^29.7.0",
 				"jest-cli": "^29.7.0",
-				"puppeteer": "^21.6.0",
+				"puppeteer": "^21.7.0",
 				"rollup-plugin-dotenv": "0.5.0"
 			}
 		},
 		"node_modules/@amplitude/analytics-browser": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.3.6.tgz",
-			"integrity": "sha512-P8N19qeoSDPO0crdQwa2yi+T0/UT4v9FqZrtXF3JW4kgxu++dTW/QkQ6bsv29EPg2N54xyr9IOt98q9EkZbA7A==",
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.3.8.tgz",
+			"integrity": "sha512-K+12aAVJPzAtWIi8Ok5Q5dvg7v7IF4G0cI8PW0COWo3uTyY103r45OcpgrpRVpVAr+41d1eiMo36jqOke89uPA==",
 			"dependencies": {
-				"@amplitude/analytics-client-common": "^2.0.9",
-				"@amplitude/analytics-core": "^2.1.2",
+				"@amplitude/analytics-client-common": "^2.0.10",
+				"@amplitude/analytics-core": "^2.1.3",
 				"@amplitude/analytics-types": "^2.3.1",
-				"@amplitude/plugin-page-view-tracking-browser": "^2.0.16",
-				"@amplitude/plugin-web-attribution-browser": "^2.0.16",
+				"@amplitude/plugin-page-view-tracking-browser": "^2.0.18",
+				"@amplitude/plugin-web-attribution-browser": "^2.0.18",
 				"tslib": "^2.4.1"
 			}
 		},
 		"node_modules/@amplitude/analytics-client-common": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.0.9.tgz",
-			"integrity": "sha512-2CSUMY60Jemks/XVro8ikuHBebENzb+IxnUz4YPx5fmBPW7QW+ysmD+LgECeLhv9jWIQoDhuciscPLuRENKerA==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.0.10.tgz",
+			"integrity": "sha512-IaERGgBN3dmCGFbFd7SFTpTBguJIQzE/uDK44KEnLj0qw9wdoTxpLhoXQpqe5WKWsr46eONL9ROCJybHs4Efnw==",
 			"dependencies": {
 				"@amplitude/analytics-connector": "^1.4.8",
-				"@amplitude/analytics-core": "^2.1.2",
+				"@amplitude/analytics-core": "^2.1.3",
 				"@amplitude/analytics-types": "^2.3.1",
 				"tslib": "^2.4.1"
 			}
@@ -56,9 +56,9 @@
 			"integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
 		},
 		"node_modules/@amplitude/analytics-core": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.1.2.tgz",
-			"integrity": "sha512-vRkP2HHh43u7vilpUrP3Q8o/TMJ6U2B7nxPV9/aUS5V/im0Zigq4mPcn5uNY7FuTwsJM3zzRxK9J2WvfdG5bqA==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.1.3.tgz",
+			"integrity": "sha512-WHXf9g33t63jYy4a/1uOpq/zHPMfEj5N2HHgJrg7Eu7v4w3kOWtPSMPBAllzFWxC5Ay5HeR9n0hqlJG0yffQWg==",
 			"dependencies": {
 				"@amplitude/analytics-types": "^2.3.1",
 				"tslib": "^2.4.1"
@@ -70,22 +70,22 @@
 			"integrity": "sha512-yojBG20qvph0rpCJKb4i/FJa+otqLINEwv//hfzvjnCOcPPyS0YscI8oiRBM0rG7kZIDgaL9a6jPwkqK4ACmcw=="
 		},
 		"node_modules/@amplitude/plugin-page-view-tracking-browser": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.16.tgz",
-			"integrity": "sha512-o9YlpXm0BcnUEK47K5xAqEa/q7DOsKGb6F35gF5iGUFXTtBP+QVLTtNujfnfiO4V9g5JrkOhB/Wm2Sr34VNFhQ==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.0.18.tgz",
+			"integrity": "sha512-s7PkGOgrx6U06/emzM8k+KRGDuyP9Z2L4OyGdeQwJcURJjiZDVQsmKlTZ5/SeGvxHYgq/4QJYUmMSmzByiGTCA==",
 			"dependencies": {
-				"@amplitude/analytics-client-common": "^2.0.9",
+				"@amplitude/analytics-client-common": "^2.0.10",
 				"@amplitude/analytics-types": "^2.3.1",
 				"tslib": "^2.4.1"
 			}
 		},
 		"node_modules/@amplitude/plugin-web-attribution-browser": {
-			"version": "2.0.16",
-			"resolved": "https://registry.npmjs.org/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.16.tgz",
-			"integrity": "sha512-IEYDrtZGJvBRhie7u9xIWNZhd0Z7heRx6A/+dNdERrW/akC1iAVmUyBZPMOR5ywVK7nwsymlVpFbPccuMoYTmg==",
+			"version": "2.0.18",
+			"resolved": "https://registry.npmjs.org/@amplitude/plugin-web-attribution-browser/-/plugin-web-attribution-browser-2.0.18.tgz",
+			"integrity": "sha512-mPlXu0fEYCCXhT6WpNJoM0FYkp+HIEm7L+KBEa2IHd3GD3+mh2AVDkZmgXLl3LKb++HY8mCiqC5/NcJ2AzTNhA==",
 			"dependencies": {
-				"@amplitude/analytics-client-common": "^2.0.9",
-				"@amplitude/analytics-core": "^2.1.2",
+				"@amplitude/analytics-client-common": "^2.0.10",
+				"@amplitude/analytics-core": "^2.1.3",
 				"@amplitude/analytics-types": "^2.3.1",
 				"tslib": "^2.4.1"
 			}
@@ -197,21 +197,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
-			"integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.5",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.5",
-				"@babel/parser": "^7.23.5",
+				"@babel/helpers": "^7.23.7",
+				"@babel/parser": "^7.23.6",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.5",
-				"@babel/types": "^7.23.5",
+				"@babel/traverse": "^7.23.7",
+				"@babel/types": "^7.23.6",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -227,12 +227,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
-			"integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.23.5",
+				"@babel/types": "^7.23.6",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -242,14 +242,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-validator-option": "^7.22.15",
-				"browserslist": "^4.21.9",
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -381,14 +381,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
-			"integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.5",
-				"@babel/types": "^7.23.5"
+				"@babel/traverse": "^7.23.7",
+				"@babel/types": "^7.23.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -480,9 +480,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
-			"integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -683,20 +683,20 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
-			"integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.5",
+				"@babel/generator": "^7.23.6",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.5",
-				"@babel/types": "^7.23.5",
-				"debug": "^4.1.0",
+				"@babel/parser": "^7.23.6",
+				"@babel/types": "^7.23.6",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -704,9 +704,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
-			"integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.23.4",
 				"@babel/helper-validator-identifier": "^7.22.20",
@@ -723,13 +723,13 @@
 			"dev": true
 		},
 		"node_modules/@ionic/core": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.0.tgz",
-			"integrity": "sha512-pDX8G915puz8OcLhxfb9MwuvpYZsUOCngJdd+61ibJ6UF+NA2mGatsMqHKzcgelTXtwcHDpi9ZLUD/HNmupqaQ==",
+			"version": "7.6.3",
+			"resolved": "https://registry.npmjs.org/@ionic/core/-/core-7.6.3.tgz",
+			"integrity": "sha512-KT8RXcbLRoCvj2wQNZJ0FAM+PlcVZZT0N3BPYPAiyTLA/rmMnlPGxNMMqGEJMynL8oPx/2nh+bLS2Yv/kBPnug==",
 			"dev": true,
 			"dependencies": {
-				"@stencil/core": "^4.8.1",
-				"ionicons": "^7.2.1",
+				"@stencil/core": "^4.8.2",
+				"ionicons": "^7.2.2",
 				"tslib": "^2.1.0"
 			}
 		},
@@ -1085,9 +1085,9 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.0.tgz",
-			"integrity": "sha512-QwguOLy44YBGC8vuPP2nmpX4MUN2FzWbsnvZJtiCzecU3lHmVZkaC1tq6rToi9a200m8RzlVtDyxCS0UIDrxUg==",
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.9.1.tgz",
+			"integrity": "sha512-PuvK6xZzGhKPvlx3fpfdM2kYY3P/hB1URtK8wA7XUJ6prn6pp22zvJHu48th0SGcHL9SutbPHrFuQgfXTFobWA==",
 			"dev": true,
 			"dependencies": {
 				"debug": "4.3.4",
@@ -1182,9 +1182,9 @@
 			}
 		},
 		"node_modules/@stencil/core": {
-			"version": "4.8.1",
-			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.8.1.tgz",
-			"integrity": "sha512-KG1H10j24rlyxIqOI4CG8/h9T7ObTv7giW2H3u1qXV4KKrLykDOpMcLzpqNXqL2Fki3s1QvHyl/oaRvi5waWVw==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.9.1.tgz",
+			"integrity": "sha512-FB3vQR2xbX8RkiKdvBRj6jAe2VunKgB4U5hWSbpdcg/GhZrwOhsEgkGUGa8hGm9bgEUpIu16in1zFqziPyBEFw==",
 			"dev": true,
 			"bin": {
 				"stencil": "bin/stencil"
@@ -1195,9 +1195,9 @@
 			}
 		},
 		"node_modules/@stencil/sass": {
-			"version": "3.0.7",
-			"resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.7.tgz",
-			"integrity": "sha512-HcBjrh2CJ6aJnkOrBNSVyf1+x3FnUneYFk44rcx/jDK6Lx7R4w0dXMEsIR5MXqtROYWonZt7WtR8wsM1vcD+6w==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-3.0.8.tgz",
+			"integrity": "sha512-QJUG4Dr/b3wSizViwQXorrk1PJzxOsKkq5hSqtUHc3NNG3iomC4DQFYGeu15yNfoCDBtt4qkyHSCynsekQ8F6A==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0.0",
@@ -1215,9 +1215,9 @@
 			"dev": true
 		},
 		"node_modules/@stencil/store": {
-			"version": "2.0.11",
-			"resolved": "https://registry.npmjs.org/@stencil/store/-/store-2.0.11.tgz",
-			"integrity": "sha512-iU803qQl8DXR1S6X4xJz6VVNgPnbhktbfLxAGe+Kx0PLJ92lBuiLKpYtPkrZNWwPOOJd3z3uSDz9UGajU4krHg==",
+			"version": "2.0.12",
+			"resolved": "https://registry.npmjs.org/@stencil/store/-/store-2.0.12.tgz",
+			"integrity": "sha512-KVO+fRDIchPQ/nZi+XEVTsmW6wtYgizMzv9eVyjlRGX0JpMAp0rpjBvh8LyLJCkrnOhGD7f3Xr6TngMIagBxtQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=12.0.0",
@@ -1247,9 +1247,9 @@
 			}
 		},
 		"node_modules/@types/babel__generator": {
-			"version": "7.6.7",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.7.tgz",
-			"integrity": "sha512-6Sfsq+EaaLrw4RmdFWE9Onp63TOUue71AWb4Gpa6JxzgTYtimbM086WnYTy2U67AofR++QKCo08ZP6pwx8YFHQ==",
+			"version": "7.6.8",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
+			"integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.0.0"
@@ -1266,17 +1266,17 @@
 			}
 		},
 		"node_modules/@types/babel__traverse": {
-			"version": "7.20.4",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.4.tgz",
-			"integrity": "sha512-mSM/iKUk5fDDrEV/e83qY+Cr3I1+Q3qqTuEn++HAWYjEa1+NxZr6CNrcJGf2ZTnq4HoFGC3zaTPZTobCzCFukA==",
+			"version": "7.20.5",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.5.tgz",
+			"integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
 			"dependencies": {
 				"@babel/types": "^7.20.7"
 			}
 		},
 		"node_modules/@types/chrome": {
-			"version": "0.0.254",
-			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.254.tgz",
-			"integrity": "sha512-svkOGKwA+6ZZuk9xtrYun8MYpNY/9hD17rgZ19v3KunhsK1ZOKaMESw12/1AXLh1u3UPA8jQIRi2370DXv9wgw==",
+			"version": "0.0.256",
+			"resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.256.tgz",
+			"integrity": "sha512-NleTQw4DNzhPwObLNuQ3i3nvX1rZ1mgnx5FNHc2KP+Cj1fgd3BrT5yQ6Xvs+7H0kNsYxCY+lxhiCwsqq3JwtEg==",
 			"dev": true,
 			"dependencies": {
 				"@types/filesystem": "*",
@@ -1354,9 +1354,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.10.3",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
-			"integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
+			"version": "20.10.8",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.8.tgz",
+			"integrity": "sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -1618,9 +1618,9 @@
 			]
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.3.tgz",
-			"integrity": "sha512-QHX8HLlncOLpy54mh+k/sWIFd0ThmRqwe9ZjELybGZK+tZ8rUb9VO0saKJUROTbE+KhzDUT7xziGpGrW8Kmd+g==",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.4.tgz",
+			"integrity": "sha512-8PzkB0arJFV4jJWSGOYR+OEic6aeKMu/osRhBULN6RY0ykby6LKhbmuQ5ublvaas5BOwboah5D87nrHyuh8PPA==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"
@@ -1747,9 +1747,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001566",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz",
-			"integrity": "sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==",
+			"version": "1.0.30001576",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
+			"integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -1792,9 +1792,9 @@
 			}
 		},
 		"node_modules/chromium-bidi": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.1.tgz",
-			"integrity": "sha512-dcCqOgq9fHKExc2R4JZs/oKbOghWpUNFAJODS8WKRtLhp3avtIH5UDCBrutdqZdh3pARogH8y1ObXm87emwb3g==",
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.5.2.tgz",
+			"integrity": "sha512-PbVOSddxgKyj+JByqavWMNqWPCoCaT6XK5Z1EFe168sxnB/BM51LnZEPXSbFcFAJv/+u2B4XNTs9uXxy4GW3cQ==",
 			"dev": true,
 			"dependencies": {
 				"mitt": "3.0.1",
@@ -2073,9 +2073,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.605",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.605.tgz",
-			"integrity": "sha512-V52j+P5z6cdRqTjPR/bYNxx7ETCHIkm5VIGuyCy3CMrfSnbEpIlLnk5oHmZo7gYvDfh2TfHeanB6rawyQ23ktg==",
+			"version": "1.4.625",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
+			"integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
 			"dev": true
 		},
 		"node_modules/emittery": {
@@ -2612,9 +2612,9 @@
 			"dev": true
 		},
 		"node_modules/ionicons": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.2.1.tgz",
-			"integrity": "sha512-2pvCM7DGVEtbbj48PJzQrCADCQrqjU1nUYX9l9PyEWz3ZfdnLdAouqwPxLdl8tbaF9cE7OZRSlyQD7oLOLnGoQ==",
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/ionicons/-/ionicons-7.2.2.tgz",
+			"integrity": "sha512-I3iYIfc9Q9FRifWyFSwTAvbEABWlWY32i0sAVDDPGYnaIZVugkLCZFbEcrphW6ixVPg8tt1oLwalo/JJwbEqnA==",
 			"dev": true,
 			"dependencies": {
 				"@stencil/core": "^4.0.3"
@@ -3992,15 +3992,15 @@
 			}
 		},
 		"node_modules/puppeteer": {
-			"version": "21.6.0",
-			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.6.0.tgz",
-			"integrity": "sha512-u6JhSF7xaPYZ2gd3tvhYI8MwVAjLc3Cazj7UWvMV95A07/y7cIjBwYUiMU9/jm4z0FSUORriLX/RZRaiASNWPw==",
+			"version": "21.7.0",
+			"resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-21.7.0.tgz",
+			"integrity": "sha512-Yy+UUy0b9siJezbhHO/heYUoZQUwyqDK1yOQgblTt0l97tspvDVFkcW9toBlnSvSfkDmMI3Dx9cZL6R8bDArHA==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
-				"@puppeteer/browsers": "1.9.0",
+				"@puppeteer/browsers": "1.9.1",
 				"cosmiconfig": "8.3.6",
-				"puppeteer-core": "21.6.0"
+				"puppeteer-core": "21.7.0"
 			},
 			"bin": {
 				"puppeteer": "lib/esm/puppeteer/node/cli.js"
@@ -4010,17 +4010,17 @@
 			}
 		},
 		"node_modules/puppeteer-core": {
-			"version": "21.6.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.6.0.tgz",
-			"integrity": "sha512-1vrzbp2E1JpBwtIIrriWkN+A0afUxkqRuFTC3uASc5ql6iuK9ppOdIU/CPGKwOyB4YFIQ16mRbK0PK19mbXnaQ==",
+			"version": "21.7.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.7.0.tgz",
+			"integrity": "sha512-elPYPozrgiM3phSy7VDUJCVWQ07SPnOm78fpSaaSNFoQx5sur/MqhTSro9Wz8lOEjqCykGC6WRkwxDgmqcy1dQ==",
 			"dev": true,
 			"dependencies": {
-				"@puppeteer/browsers": "1.9.0",
-				"chromium-bidi": "0.5.1",
+				"@puppeteer/browsers": "1.9.1",
+				"chromium-bidi": "0.5.2",
 				"cross-fetch": "4.0.0",
 				"debug": "4.3.4",
 				"devtools-protocol": "0.0.1203626",
-				"ws": "8.14.2"
+				"ws": "8.16.0"
 			},
 			"engines": {
 				"node": ">=16.13.2"
@@ -4276,9 +4276,9 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.15.5",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.5.tgz",
-			"integrity": "sha512-9thPGMkKC2GctCzyCUjME3yR03x2xNo0GPKGkRw2UMYN+gqWa9uqpyNWhmsNCutU5zHmkUum0LsCRQTXUgUCAg==",
+			"version": "2.15.6",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.15.6.tgz",
+			"integrity": "sha512-q+vQL4AAz+FdfT137VF69Cc/APqUbxy+MDOImRrMvchJpigHj9GksgDU2LYbO9rx7RX6osWgxJB2WxhYv4SZAw==",
 			"dev": true,
 			"dependencies": {
 				"fast-fifo": "^1.1.0",
@@ -4642,9 +4642,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.14.2",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.14.2.tgz",
-			"integrity": "sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+			"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=10.0.0"

--- a/panel-app/package.json
+++ b/panel-app/package.json
@@ -11,7 +11,7 @@
 		"generate": "stencil generate"
 	},
 	"devDependencies": {
-		"@ionic/core": "^7.6.3",
+		"@ionic/core": "^7.6.4",
 		"@stencil-community/router": "^1.0.2",
 		"@stencil/core": "4.9.1",
 		"@stencil/sass": "^3.0.8",

--- a/panel-app/package.json
+++ b/panel-app/package.json
@@ -11,21 +11,21 @@
 		"generate": "stencil generate"
 	},
 	"devDependencies": {
-		"@ionic/core": "^7.6.0",
+		"@ionic/core": "^7.6.3",
 		"@stencil-community/router": "^1.0.2",
-		"@stencil/core": "4.8.1",
-		"@stencil/sass": "^3.0.7",
-		"@stencil/store": "^2.0.11",
-		"@types/chrome": "^0.0.254",
+		"@stencil/core": "4.9.1",
+		"@stencil/sass": "^3.0.8",
+		"@stencil/store": "^2.0.12",
+		"@types/chrome": "^0.0.256",
 		"@types/jest": "^29.5.11",
 		"jest": "^29.7.0",
 		"jest-cli": "^29.7.0",
-		"puppeteer": "^21.6.0",
+		"puppeteer": "^21.7.0",
 		"rollup-plugin-dotenv": "0.5.0"
 	},
 	"dependencies": {
-		"@amplitude/analytics-browser": "^2.3.6",
-		"@types/babel__traverse": "^7.20.4",
+		"@amplitude/analytics-browser": "^2.3.8",
+		"@types/babel__traverse": "^7.20.5",
 		"uuid": "^9.0.1"
 	},
 	"browserslist": [

--- a/panel-app/src/components/app-root/app-root.tsx
+++ b/panel-app/src/components/app-root/app-root.tsx
@@ -21,8 +21,6 @@ export class AppRoot {
 
 	componentDidLoad() {
 		const tabId = chrome.devtools?.inspectedWindow?.tabId;
-		// chrome.scripting.executeScript({ target: { tabId }, files: ['content-script.js'] });
-		// chrome.scripting.insertCSS({ target: { tabId }, files: ['css/inject.css'] });
 		chrome.scripting.executeScript({ target: { tabId }, func: injectedFunction, args: [tabId] });
 
 		initializeAmplitude();

--- a/panel-app/src/components/app-root/app-root.tsx
+++ b/panel-app/src/components/app-root/app-root.tsx
@@ -5,6 +5,11 @@ import logo from '../../assets/icon/CoveoLogo.svg';
 import state from '../store';
 import { initializeAmplitude, logEvent } from '../analytics';
 
+function injectedFunction(tabId: number) {
+	(window as any).__WSH_tabid = tabId;
+	// console.log('set tabID: ', (window as any).__WSH_tabid);
+}
+
 @Component({
 	tag: 'app-root',
 	styleUrl: 'app-root.scss',
@@ -14,6 +19,11 @@ export class AppRoot {
 	@State() version: string = '';
 
 	componentDidLoad() {
+		const tabId = chrome.devtools?.inspectedWindow?.tabId;
+		// chrome.scripting.executeScript({ target: { tabId }, files: ['content-script.js'] });
+		// chrome.scripting.insertCSS({ target: { tabId }, files: ['css/inject.css'] });
+		chrome.scripting.executeScript({ target: { tabId }, func: injectedFunction, args: [tabId] });
+
 		initializeAmplitude();
 		try {
 			let manifest = chrome.runtime.getManifest();

--- a/panel-app/src/components/app-root/app-root.tsx
+++ b/panel-app/src/components/app-root/app-root.tsx
@@ -5,6 +5,7 @@ import logo from '../../assets/icon/CoveoLogo.svg';
 import state from '../store';
 import { initializeAmplitude, logEvent } from '../analytics';
 
+// This function is run in the context of the inspected page, to set the tabID used in the event handlers.
 function injectedFunction(tabId: number) {
 	(window as any).__WSH_tabid = tabId;
 	// console.log('set tabID: ', (window as any).__WSH_tabid);

--- a/panel-app/src/components/create-config/create-config.tsx
+++ b/panel-app/src/components/create-config/create-config.tsx
@@ -5,6 +5,7 @@ import infoToken from '../../assets/icon/InfoToken.svg';
 import { SubItem } from '../types';
 import { getScraperConfigMetrics, logEvent } from '../analytics';
 
+// This function is run in the context of the inspected page, to set the tabID used in the event handlers.
 function injectedFunction(tabId: number) {
 	(window as any).__WSH_tabid = tabId;
 }
@@ -147,11 +148,6 @@ export class CreateConfig {
 		await this.loadFile();
 		this.addPageLoadListener();
 	}
-
-	// disconnectedCallback() {
-	// 	console.log('CC-UNLOAD: ', this.tabId);
-	// 	chrome.runtime.onMessage.removeListener(this.pageLoadListener);
-	// }
 
 	componentDidLoad() {
 		// log tab view on eeach current/new-file open

--- a/panel-app/src/components/create-config/create-config.tsx
+++ b/panel-app/src/components/create-config/create-config.tsx
@@ -27,7 +27,6 @@ export class CreateConfig {
 		this.pageLoadListener = (message) => {
 			if (message.type === 'page-loaded') {
 				const tabId = this.tabId;
-				chrome.scripting.insertCSS({ target: { tabId }, files: ['css/inject.css'] });
 				chrome.scripting.executeScript({ target: { tabId }, files: ['content-script.js'] });
 				chrome.scripting.executeScript({ target: { tabId }, func: injectedFunction, args: [this.tabId] });
 				this.loadFile();
@@ -119,7 +118,6 @@ export class CreateConfig {
 		}
 
 		const tabId = this.tabId;
-		await chrome.scripting.insertCSS({ target: { tabId }, files: ['css/inject.css'] });
 		await chrome.scripting.executeScript({ target: { tabId }, files: ['content-script.js'] });
 
 		try {

--- a/panel-app/src/components/create-config/create-config.tsx
+++ b/panel-app/src/components/create-config/create-config.tsx
@@ -93,7 +93,7 @@ export class CreateConfig {
 		updateGlobalName(e.detail.value);
 	}
 
-	async componentWillLoad() {
+	async loadFile() {
 		try {
 			if (state.currentFile?.triggerType === 'load-file') {
 				const fileName = state.currentFile.name;
@@ -110,6 +110,19 @@ export class CreateConfig {
 		} catch (e) {
 			console.log(e);
 		}
+	}
+
+	addPageLoadListener() {
+		chrome.runtime.onMessage.addListener((message) => {
+			if (message.type === 'page-loaded') {
+				this.loadFile();
+			}
+		});
+	}
+
+	async componentWillLoad() {
+		this.loadFile();
+		this.addPageLoadListener();
 	}
 
 	componentDidLoad() {

--- a/panel-app/src/components/store.ts
+++ b/panel-app/src/components/store.ts
@@ -291,9 +291,10 @@ const addToRecentFiles = async (filename: string): Promise<string[]> => {
 
 const sendMessageToContentScript = (message: any, callback: any = null): any => {
 	try {
+		const tabId = chrome.devtools?.inspectedWindow?.tabId;
 		chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
 			console.log('tabs', tabs);
-			if (tabs?.length && tabs[0].id) chrome.tabs.sendMessage(tabs[0].id, message, null, callback);
+			if (tabs?.length && tabs[0].id) chrome.tabs.sendMessage(tabs[0].id, { tabId, ...message }, null, callback);
 		});
 	} catch (e) {
 		console.log(e);


### PR DESCRIPTION
I changed the loading sequence for the `content-script`.
The extension is now loading `content-reload.js` on each page. This file is simply setting up a listener for events from the extension, and an observer for url changes.
This makes the application more lightweight, as it doesn't add content-script on all pages when the Web Scraper  Helper (`WSH`) is not really used (and the dev tool panels is opened in other tabs).

When opening a configuration in the WSH, the `<create-config>` component will inject `content-script.js` and the css. 
There are guards against injecting it multiple times (ie. the variable `window.__WSH_content_script_loaded`).

When the inspected page is changed, `content-reload` with send a message to `<create-config>` if a configuration is loaded, and the extension will re-inject the script and apply the config again.

In the case of Single Page Apps, the page isn't really reloaded, so it be caught but the Observer in `content-reload`.

-----
Also: 
When we have multiple pages and WSH opened, we need to make sure they don't get mixed up in the events. 
We prevent that with using `tabId` as the target of the events. When receiving events in `content-script`, we make sure it's intended for this page before applying the styling. 